### PR TITLE
Add player and developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # space-truckers
+
+An interactive fiction game built in [Ink](https://github.com/inkle/ink) about hauling cargo across the solar system.
+
+## Documentation
+
+- [Player Guide](docs/player-guide.md) — how to play
+- [Developer Guide](docs/developer-guide.md) — design goals, formulas, and how to extend the game

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,223 @@
+# Space Truckers — Developer Guide
+
+This document explains the design goals and mathematical foundations of the Space Truckers gameplay systems. It is intended for developers who need to understand *why* the numbers are the way they are, not just what they are.
+
+---
+
+## Core Gameplay Loop
+
+The central design goal is to let the player make meaningful choices between four variables on every run:
+
+- **Mass** — how much cargo to carry
+- **Distance** — how far the destination is
+- **Time** — how long the trip will take
+- **Efficiency** — how much fuel each engine mode burns
+
+No single run is the "obviously correct" choice. A heavier load earns more money but costs more fuel. A faster engine mode saves time but empties the tank. The player is always trading one resource against another. All other systems — engine tiers, cargo flags, fuel pricing — exist to deepen and vary that core trade-off, not to replace it.
+
+---
+
+## Distance Units
+
+Distances are internal, abstract units. They are never displayed to the player and do not correspond to real astronomical distances. They are tuned to produce satisfying fuel cost and trip duration numbers at each engine tier.
+
+| Route | Distance |
+|---|---|
+| Earth ↔ Luna | 5 |
+| Luna ↔ Mars | 8 |
+| Earth ↔ Mars | 14 |
+| Mars ↔ Ceres | 10 |
+| Luna ↔ Ceres | 18 |
+| Earth ↔ Ceres | 22 |
+| Ceres ↔ Ganymede | 18 |
+| Mars ↔ Ganymede | 26 |
+| Ganymede ↔ Titan | 16 |
+| Mars ↔ Titan | 36 |
+| Ceres ↔ Titan | 28 |
+| Earth ↔ Ganymede | 40 |
+| Luna ↔ Titan | 50 |
+| Earth ↔ Titan | 52 |
+
+The inner system (Earth, Luna, Mars) is tightly clustered with distances of 5–14. The belt (Ceres) sits in a middle band at 10–22 from inner planets. The outer system (Ganymede, Titan) is substantially further, at 16–52. This spread means early-game players genuinely cannot reach the outer system in one hop, and late-game players who can do so have a real advantage in route efficiency.
+
+---
+
+## Engine Tiers
+
+There are four engine tiers. The player starts with tier 1 and can purchase upgrades to reach tier 4.
+
+Each tier has seven stats: `FuelCap`, `EcoFuel`, `EcoSpeed`, `BalFuel`, `BalSpeed`, `TurboFuel`, `TurboSpeed`.
+
+| Tier | FuelCap | EcoFuel | EcoSpeed | BalFuel | BalSpeed | TurboFuel | TurboSpeed |
+|---|---|---|---|---|---|---|---|
+| 1 (starter) | 300 | 1.1 | 1.0 | 2.0 | 1.5 | 4.0 | 2.5 |
+| 2 | 500 | 0.8 | 1.0 | 1.5 | 2.0 | 3.0 | 3.0 |
+| 3 | 650 | 0.5 | 1.5 | 0.9 | 2.5 | 1.8 | 4.0 |
+| 4 | 800 | 0.3 | 2.0 | 0.6 | 3.5 | 1.2 | 5.0 |
+
+`FuelFactor` values are multipliers in the fuel cost formula (lower is better). `Speed` values are divisors in the trip duration formula (higher is faster).
+
+### What Each Tier Unlocks
+
+The engine upgrade path is designed to change *how* the player navigates the solar system, not just how profitable each run is.
+
+**Tier 1 (starter):** Inner system only — Earth, Luna, Mars. Economy mode is the only viable option for most loads. Balance mode breaks even or loses money. Turbo is essentially unusable. The player is doing methodical planet-hopping at thin margins (~17% profit on a decent load). The outer system is technically reachable via multi-hop but uses 88–99% of the tank on each leg — dangerously risky.
+
+**Tier 2:** The belt opens up. Earth→Ceres, Mars→Ceres, and Ceres→Ganymede become viable at light loads. Inner-system margins improve. Crucially, Balance mode becomes *usable* on inner-system runs even though Economy speed hasn't changed — the player suddenly feels faster because they can afford to go faster. Outer-system single-hop routes are still unreachable, but a careful player can now do two-leg outer-system runs.
+
+**Tier 3:** The outer system opens up. Ganymede and Titan routes become accessible. Economy speed improves noticeably (Earth→Mars drops from 14 days to ~9 days). The map feels larger and more open. Balance mode is now financially viable on almost all routes.
+
+**Tier 4:** Long-haul routes that were previously multi-day ordeals become quick runs. Earth→Titan, which took weeks in tier 1, is now a meaningful option. Turbo mode is affordable on most routes. The player's late-game decisions are about maximising revenue and managing Express/Hazardous cargo flags, not about whether they can physically reach a destination.
+
+### Why v1 and v2 Have the Same Economy Speed
+
+This is intentional. The v2 upgrade feels financial rather than viscerally faster — better margins, new routes. The speed improvement lands at v3, which makes that upgrade feel like a qualitative shift in how the game plays. If speed improved at every tier, upgrades would feel more uniform and less memorable.
+
+---
+
+## Fuel Cost Formula
+
+```
+fuel_cost = FLOOR(distance × total_mass × fuel_factor)
+```
+
+Where `total_mass = cargo_mass + 5` (the +5 represents the ship's own mass, so an empty ship still burns some fuel).
+
+`fuel_factor` comes from `EngineData` for the current tier and chosen mode (EcoFuel, BalFuel, or TurboFuel).
+
+### Why Mass Is in the Fuel Formula
+
+Carrying more cargo costs proportionally more fuel. This creates the core tension: a heavier load earns more pay but leaves less fuel margin, which may force the player into a slower mode or require them to top up mid-route.
+
+### Why There Is a Ship Mass Constant
+
+Without the +5 ship mass, an empty ship would cost zero fuel to move, which breaks the economics of deadheading (flying empty to reposition). The constant also ensures that even the lightest possible cargo load produces a non-trivial fuel cost.
+
+---
+
+## Trip Duration Formula
+
+```
+duration = MAX(FLOOR(distance / speed), 1)
+```
+
+`speed` comes from `EngineData` for the current tier and chosen mode (EcoSpeed, BalSpeed, TurboSpeed). The `MAX(..., 1)` clamp ensures no trip is instantaneous — even the shortest route at the fastest engine tier takes at least 1 day.
+
+### Why Mass Does Not Affect Duration
+
+Trip time is a function of how fast the engine pushes the ship, not how heavy the load is. This is a deliberate simplification: if mass affected both cost *and* duration, the player would always want to fly light. Keeping duration mass-independent means a heavy load is only penalised in fuel cost, not in time — which preserves the trade-off: heavy loads earn more and cost more fuel, but don't necessarily cost more time.
+
+---
+
+## Pay Formula
+
+```
+base_pay = FLOOR(mass × distance × PayRate)
+```
+
+`PayRate` is a global constant, currently set to `3`.
+
+Each applicable cargo flag adds a 50% bonus on top of base pay:
+
+```
+total_pay = base_pay + (number_of_flags × FLOOR(base_pay / 2))
+```
+
+Flags that add +50%: `Express`, `Fragile`, `Hazardous`, `Passengers`.
+
+### Why Computed Pay Instead of Hard-Coded Pay
+
+Pay is derived from the same distance table used for fuel costs. This guarantees that longer routes always pay more, shorter routes always pay less, and new cargo entries or route changes never require manually recalculating payouts. It also means the player can intuitively reason about value: "longer route, bigger cargo, more pay."
+
+### Why PayRate = 3
+
+At `PayRate = 3`, a typical inner-system run (e.g., 20t of cargo, Earth→Mars, distance 14) earns `FLOOR(20 × 14 × 3) = €840`. The fuel cost for that run at tier 1 Economy is roughly `FLOOR(14 × 25 × 1.1) = €385` at €1.2/unit. That's approximately a 54% margin — enough to feel rewarding without being easy. Balance mode on the same run costs roughly €700 in fuel, squeezing the margin to ~17%. Turbo mode exceeds the tank capacity entirely, which is exactly the intended constraint.
+
+### Why the Flag Bonus Is +50% Per Flag (Not a Multiplier)
+
+A flat additive bonus per flag keeps the math transparent. The player can see: "this cargo has two flags, so it pays 2× the base bonus on top of standard rate." A compounding multiplier would make multi-flag cargo disproportionately lucrative and harder to reason about.
+
+---
+
+## Fuel Pricing Zones
+
+Fuel prices vary by location zone:
+
+| Zone | Locations | Price per Unit |
+|---|---|---|
+| Inner system | Earth, Luna, Mars | €1.2 |
+| Belt | Ceres | €1.0 |
+| Outer system | Ganymede, Titan | €0.8 |
+
+### Why Inner Fuel Is Most Expensive
+
+This is deliberately counter-intuitive but economically motivated: inner-system locations are mature, high-demand markets. The outer system is sitting on ice deposits, helium, and methane — raw fuel is abundant and cheap if you can get there. This creates a natural incentive that reinforces the upgrade progression: push further out, pay less for fuel, make bigger profits — but you need a better engine to get there.
+
+In early game, the player is paying premium prices at inner ports. In late game, they're refuelling cheaply at outer-system stations and turning larger margins.
+
+---
+
+## Cargo Flags
+
+Flags are boolean properties stored in `CargoStats` and queried via `CargoData`. Each flag has a gameplay effect that creates a constraint or a decision.
+
+| Flag | Pay Bonus | Constraint |
+|---|---|---|
+| Express | +50% | Turbo mode only; all Express cargo must share one destination |
+| Fragile | +50% | No Turbo mode |
+| Hazardous | +50% | Cannot mix with non-Hazardous cargo in the same hold |
+| Passengers | +50% | No Turbo mode |
+
+### Why These Specific Constraints
+
+Each flag is designed to interact with the core mass/time/distance/efficiency trade-off in a distinct way:
+
+- **Express** forces the player to prioritise speed over fuel cost. The higher pay partially compensates but requires either a light load (to afford Turbo) or careful fuel management.
+- **Fragile** and **Passengers** remove Turbo from the table, making them inherently slower trips. The pay bonus compensates for the time cost.
+- **Hazardous** forces exclusivity — you can't mix it with other cargo. This caps your earning potential per run (you're filling the hold with one contract), which the pay bonus partially offsets.
+
+The goal is that no flag is a pure upside. Each one closes off an option while opening a financial reward, so the player is always making a real choice about whether to take the contract.
+
+---
+
+## The `None` Sentinel Value
+
+`AllLocations` includes `None` as its first (lowest-value) entry. This is a sentinel used by `cargo_express_destination` to represent "no Express destination found yet." It was chosen over an integer `0` because Ink cannot compare list values to integers with `==`. `None` is always safe to use as a sentinel because no cargo is ever bound for `None`.
+
+---
+
+## Adding New Content
+
+### New Cargo Entry
+
+Add a line to `CargoData` in `cargo.ink` using `cargo_db`:
+
+```ink
+- NNN_Name:
+    ~ return cargo_db(data, FromLocation, ToLocation, massInTons, "display name", isExpress, isFragile, isHazardous, isPassengers)
+```
+
+Pay is computed automatically from mass and distance. No manual payout calculation needed.
+
+### New Location
+
+1. Add the location to `AllLocations` in `locations.ink`
+2. Add a row to `LocationData` with distances to all other locations
+3. Add a column to `location_db` for the new location
+4. Add a fuel price case to `get_fuel_price`
+
+### New Engine Tier
+
+Add a row to `EngineData` in `space-truckers.ink`. Use the tier progression table above as a guide — each tier should make at least one mode feel qualitatively different from the previous tier, not just numerically better.
+
+---
+
+## Running the Compiler
+
+After any changes to `.ink` files, always validate before committing:
+
+```bash
+npm run lint
+```
+
+This compiles the full story from `space-truckers.ink` and reports any errors. `TODO:` messages are informational; `ERROR:` lines must be fixed before the game will run.

--- a/docs/player-guide.md
+++ b/docs/player-guide.md
@@ -1,0 +1,114 @@
+# Space Truckers — Player Guide
+
+Welcome to Space Truckers. You're the owner-operator of a small cargo hauler working the inner solar system. The work is simple: pick up contracts, fly to the destination, get paid. The trick is making enough money to keep flying.
+
+---
+
+## The Basic Idea
+
+Every run comes down to the same four questions:
+
+1. **What am I hauling?** (mass)
+2. **How far is it?** (distance)
+3. **How long am I willing to take?** (time)
+4. **How much fuel can I afford to burn?** (efficiency)
+
+Your job is to balance those four things. A perfect run isn't always the fastest one, or the most profitable one — it's the one that keeps you in business for the next run.
+
+---
+
+## Your Ship
+
+Your starter ship is a reliable workhorse, but it has limits. The fuel tank is modest, and the engine isn't particularly efficient. In the early game, you'll mostly be making short hops between Earth, the Moon, and Mars. That's fine — there's money to be made there, and you'll learn the ropes before venturing further out.
+
+The most important number to watch is your **fuel gauge**. Before every departure, the game shows you how much fuel each flight option will cost. If a mode would empty your tank (or more), it won't be available. Plan accordingly.
+
+---
+
+## Engine Modes
+
+Every departure offers up to three modes. Each one trades time against fuel:
+
+### Economy Mode
+
+Burns the least fuel. Takes the longest. Good for heavy loads on shorter routes, or any time you're running low on cash and need to conserve. In the early game, Economy is your bread and butter.
+
+### Balance Mode
+
+A middle ground. Faster than Economy, cheaper than Turbo. As your engine improves, Balance mode becomes your default for most runs — a reasonable speed without punishing your wallet.
+
+### Turbo Mode
+
+Burns a lot of fuel. Gets you there fast. In the early game, Turbo is often simply out of reach — your tank isn't big enough to afford it. It becomes more accessible as you upgrade, and is essential for Express cargo (see below).
+
+The key insight: **the same engine mode feels different depending on how much you're carrying.** A light load costs less fuel in any mode, which means Turbo might be affordable for a small shipment when it wouldn't be for a full hold. Part of the skill of the game is matching your load to your mode.
+
+---
+
+## Cargo
+
+At each port, you'll find a selection of cargo contracts. Each one shows you:
+
+- **What it is** and what it weighs
+- **Where it's going**
+- **How much it pays**
+
+Pay is calculated from the weight of the cargo and the distance to the destination. Heavy cargo going far pays well. Light cargo going next door pays modestly. There's no catch — the numbers are straightforward.
+
+### Special Cargo
+
+Some contracts come with extra conditions, marked in the loading screen:
+
+**Express** — Time-sensitive cargo (fresh produce, medical supplies, that sort of thing). It pays a premium, but it *requires Turbo mode*, and all your Express contracts must be going to the same destination. You can't run Express cargo halfway to Mars if you've got a different Express shipment bound for the Moon.
+
+**Fragile** — Handle with care. No Turbo mode. The reduced thrust keeps it safe. The pay bonus compensates for the extra time.
+
+**Hazardous** — Dangerous materials. You can carry Hazardous cargo, but you can't mix it with anything else in the hold. A full load of hazmat pays well; a half-load of hazmat and a half-load of moonshine isn't allowed.
+
+**Passengers** — Humans have limits. No Turbo mode. Same deal as Fragile, essentially — slower trip, better pay.
+
+---
+
+## Fuel
+
+You buy fuel at port. The price varies depending on where you are:
+
+- **Inner system** (Earth, Moon Base, Mars) — most expensive
+- **Ceres Station** — mid-range
+- **Outer system** (Ganymede Outpost, Titan Base) — cheapest
+
+This might seem backwards, but it makes sense: the outer planets are rich in raw fuel sources. Ice deposits, methane, helium — fuel is abundant out there. Getting to those cheap fuelling stations is part of the reward for flying further from home.
+
+---
+
+## Engine Upgrades
+
+The biggest improvement you can make to your ship is upgrading the engine. Each generation of engine is more efficient and faster in every mode.
+
+When you're flying a tier 1 starter engine, here's what you're living with:
+- Economy mode is slow and tight. You can make money, but you won't get rich.
+- Balance mode is a luxury you often can't afford.
+- Turbo mode is mostly theoretical.
+- The outer system is out of reach. The belt is a stretch.
+
+As you upgrade:
+- Economy mode gets noticeably faster. A run that used to take two weeks takes a week.
+- Balance mode becomes affordable on most routes.
+- Turbo mode stops being a last resort and becomes a genuine option.
+- Routes you had to multi-hop become direct flights.
+
+The late-game feeling is qualitatively different from the early game. Your first run to Titan might be a carefully planned multi-leg journey. Your last run to Titan is just another Tuesday.
+
+---
+
+## A Few Tips
+
+**Start local.** Earth↔Moon and Earth↔Mars runs might feel small, but they're reliable. Learn the economics before venturing further out.
+
+**Watch your fuel before you commit.** The departure screen shows fuel costs for every available mode. Check them before you choose. Running out of fuel mid-transit isn't an option — you need enough to complete the trip.
+
+**Light loads unlock faster modes.** If you're eyeing Express cargo but your tank won't cover Turbo with a full hold, consider taking less. A lighter load at a higher mode can pay more than a heavy load at Economy.
+
+**Hazardous pays well, but think it through.** Accepting Hazardous cargo means your whole hold is committed to that one contract. Make sure the payout is worth giving up the rest of your capacity.
+
+**Cheap outer-system fuel is worth the trip.** Once your engine can reach Ceres or Ganymede reliably, refuelling there instead of at Earth saves money on every subsequent run.


### PR DESCRIPTION
## Summary

- Adds `docs/developer-guide.md` — full design reference for developers covering the core gameplay loop, all formulas (fuel cost, duration, pay), engine tier progression rationale and what each tier unlocks, cargo flag design intent, fuel pricing zone design, the `None` sentinel, and how to add new cargo/locations/engine tiers
- Adds `docs/player-guide.md` — player-facing guide explaining the mass/time/distance/efficiency loop, engine modes, special cargo types (Express, Fragile, Hazardous, Passengers), fuel pricing, and the engine upgrade arc without exposing internal math
- Updates `README.md` to link to both documents

## Test plan

- [ ] Read both docs and verify all formulas and numbers match the current code
- [ ] Verify README links resolve correctly

Made with [Cursor](https://cursor.com)