### PR TITLE
Reduce Tier 1 Balance fuel factor from 2.0 to 1.8

### DIFF
--- a/simulator.html
+++ b/simulator.html
@@ -273,7 +273,7 @@ const SHIP_MASS = 5;
 const ENGINES = [
   { tier: 1, fuelCap: 300, modes: [
     { name: 'Eco',     fuelFactor: 1.1, speed: 1.0 },
-    { name: 'Balance', fuelFactor: 2.0, speed: 1.5 },
+    { name: 'Balance', fuelFactor: 1.8, speed: 1.5 },
     { name: 'Turbo',   fuelFactor: 4.0, speed: 2.5 },
   ]},
   { tier: 2, fuelCap: 500, modes: [

--- a/space-truckers.ink
+++ b/space-truckers.ink
@@ -27,7 +27,7 @@ LIST EngineStats = FuelCap, EcoFuel, EcoSpeed, BalFuel, BalSpeed, TurboFuel, Tur
 === function EngineData(tier, stat)
 { tier:
 - 1:
-    ~ return engine_db(stat, 300, 1.1, 1.0, 2.0, 1.5, 4.0, 2.5)
+    ~ return engine_db(stat, 300, 1.1, 1.0, 1.8, 1.5, 4.0, 2.5)
 - 2:
     ~ return engine_db(stat, 500, 0.8, 1.0, 1.5, 2.0, 3.0, 3.0)
 - 3:


### PR DESCRIPTION
## Summary

- Lowers the Tier 1 Balance mode fuel factor from `2.0` to `1.8` in `space-truckers.ink`
- Updates the matching value in the `simulator.html` game data block

## Motivation

At `2.0`, Balance mode on Tier 1 required exactly 20t of cargo just to break even on a Luna run, and 10t always ran at a loss (-€30). This made Balance feel like a trap for early-game players who hadn't yet learned the load efficiency lesson.

At `1.8`:

| Route | Mass | Old profit | New profit |
|---|---|---|---|
| Earth → Luna | 10t | -€30 | -€12 |
| Earth → Luna | 20t | €0 (break even) | +€30 |
| Earth → Mars | any | infeasible | infeasible |

Mars in Balance remains fully infeasible on Tier 1, preserving the Tier 2 upgrade as a meaningful unlock.

## Test plan

- [ ] Verify Earth → Luna, Balance, 20t yields a positive profit in the simulator
- [ ] Verify Earth → Luna, Balance, 10t still yields a loss in the simulator
- [ ] Verify Earth → Mars remains infeasible for Balance on Tier 1 in the simulator
- [ ] Verify the Ink game produces consistent results with the updated fuel factor

Made with [Cursor](https://cursor.com)