### PR TITLE
Add engine manufacturer system: Kepler, Olympus, Huygens

### DIFF
--- a/cargo.ink
+++ b/cargo.ink
@@ -1542,7 +1542,7 @@ LIST AllCargo =
 }
 // Filter out cargo the player can't physically carry to its destination
 ~ temp trip_mass = CargoData(cargo, Mass) + 5
-~ temp eco_fuel = EngineData(ShipEngineTier, EcoFuel)
+~ temp eco_fuel = EngineData(ShipManufacturer, ShipEngineTier, EcoFuel)
 ~ temp trip_cost = FLOOR(get_distance(here, CargoData(cargo, To)) * trip_mass * eco_fuel)
 { trip_cost > ShipFuelCapacity:
     ~ return false
@@ -1559,7 +1559,7 @@ LIST AllCargo =
 
 */
 === function can_turbo_to(destination)
-~ temp turbo_fuel = EngineData(ShipEngineTier, TurboFuel)
+~ temp turbo_fuel = EngineData(ShipManufacturer, ShipEngineTier, TurboFuel)
 ~ return get_trip_fuel_cost(here, destination, turbo_fuel) <= ShipFuelCapacity
 
 /*

--- a/port.ink
+++ b/port.ink
@@ -210,7 +210,7 @@ The current unit cost of fuel is {price} €. Your fuel gauge reads {ShipFuel}/{
 + {here != Titan}    [Go to {LocationData(Titan, Name)}]    -> flight_options(Titan)
 + [Cancel] -> port_opts
 
-// TODO: on engine upgrade, run: ~ ShipFuelCapacity = EngineData(ShipEngineTier, FuelCap)
+// TODO: on engine upgrade, run: ~ ShipFuelCapacity = EngineData(ShipManufacturer, ShipEngineTier, FuelCap)
 
 /*
 
@@ -219,12 +219,12 @@ The current unit cost of fuel is {price} €. Your fuel gauge reads {ShipFuel}/{
 
 */
 = flight_options(to)
-~ temp eco_fuel    = EngineData(ShipEngineTier, EcoFuel)
-~ temp bal_fuel    = EngineData(ShipEngineTier, BalFuel)
-~ temp turbo_fuel  = EngineData(ShipEngineTier, TurboFuel)
-~ temp eco_speed   = EngineData(ShipEngineTier, EcoSpeed)
-~ temp bal_speed   = EngineData(ShipEngineTier, BalSpeed)
-~ temp turbo_speed = EngineData(ShipEngineTier, TurboSpeed)
+~ temp eco_fuel    = EngineData(ShipManufacturer, ShipEngineTier, EcoFuel)
+~ temp bal_fuel    = EngineData(ShipManufacturer, ShipEngineTier, BalFuel)
+~ temp turbo_fuel  = EngineData(ShipManufacturer, ShipEngineTier, TurboFuel)
+~ temp eco_speed   = EngineData(ShipManufacturer, ShipEngineTier, EcoSpeed)
+~ temp bal_speed   = EngineData(ShipManufacturer, ShipEngineTier, BalSpeed)
+~ temp turbo_speed = EngineData(ShipManufacturer, ShipEngineTier, TurboSpeed)
 ~ temp slow_cost   = get_trip_fuel_cost(here, to, eco_fuel)
 ~ temp norm_cost   = get_trip_fuel_cost(here, to, bal_fuel)
 ~ temp fast_cost   = get_trip_fuel_cost(here, to, turbo_fuel)

--- a/simulator.html
+++ b/simulator.html
@@ -342,6 +342,14 @@
 
 <div class="controls">
   <div class="control-group">
+    <label for="sel-mfg">Manufacturer</label>
+    <select id="sel-mfg">
+      <option value="0">Kepler Drive Systems (Earth)</option>
+      <option value="1">Olympus Propulsion (Mars)</option>
+      <option value="2">Huygens Deepspace (Titan)</option>
+    </select>
+  </div>
+  <div class="control-group">
     <label for="sel-tier">Engine Tier</label>
     <select id="sel-tier">
       <option value="0">Tier 1 (Starter)</option>
@@ -442,30 +450,77 @@ const PAY_RATE  = 3;
 // space-truckers.ink: constant ship hull mass added to cargo for fuel calc
 const SHIP_MASS = 5;
 
-// engines.ink: EngineData table — fuelCap, and per-mode [fuelFactor, speed]
+// space-truckers.ink: EngineData table — fuelCap, and per-mode [fuelFactor, speed]
 // Modes: Eco = [EcoFuel, EcoSpeed], Balance = [BalFuel, BalSpeed], Turbo = [TurboFuel, TurboSpeed]
-const ENGINES = [
-  { tier: 1, fuelCap: 300, modes: [
-    { name: 'Eco',     fuelFactor: 1.1, speed: 1.0 },
-    { name: 'Balance', fuelFactor: 1.8, speed: 1.5 },
-    { name: 'Turbo',   fuelFactor: 4.0, speed: 2.5 },
-  ]},
-  { tier: 2, fuelCap: 500, modes: [
-    { name: 'Eco',     fuelFactor: 0.8, speed: 1.0 },
-    { name: 'Balance', fuelFactor: 1.5, speed: 2.0 },
-    { name: 'Turbo',   fuelFactor: 3.0, speed: 3.0 },
-  ]},
-  { tier: 3, fuelCap: 650, modes: [
-    { name: 'Eco',     fuelFactor: 0.5, speed: 1.5 },
-    { name: 'Balance', fuelFactor: 0.9, speed: 2.5 },
-    { name: 'Turbo',   fuelFactor: 1.8, speed: 4.0 },
-  ]},
-  { tier: 4, fuelCap: 800, modes: [
-    { name: 'Eco',     fuelFactor: 0.3, speed: 2.0 },
-    { name: 'Balance', fuelFactor: 0.6, speed: 3.5 },
-    { name: 'Turbo',   fuelFactor: 1.2, speed: 5.0 },
-  ]},
-];
+// Manufacturers: Kepler (Earth, balanced), Olympus (Mars, turbo), Huygens (Titan, eco)
+// Tier 1 is a universal starter engine shared by all manufacturers.
+const MFG_KEYS = ['kepler', 'olympus', 'huygens'];
+
+const TIER_1 = { tier: 1, fuelCap: 300, modes: [
+  { name: 'Eco',     fuelFactor: 1.1, speed: 1.0 },
+  { name: 'Balance', fuelFactor: 1.8, speed: 1.5 },
+  { name: 'Turbo',   fuelFactor: 4.0, speed: 2.5 },
+]};
+
+const ENGINES = {
+  // Kepler Drive Systems (Earth) — balanced, best Balance mode
+  kepler: [
+    TIER_1,
+    { tier: 2, fuelCap: 500, modes: [
+      { name: 'Eco',     fuelFactor: 0.8, speed: 1.1 },
+      { name: 'Balance', fuelFactor: 1.5, speed: 2.0 },
+      { name: 'Turbo',   fuelFactor: 3.0, speed: 3.0 },
+    ]},
+    { tier: 3, fuelCap: 650, modes: [
+      { name: 'Eco',     fuelFactor: 0.5, speed: 1.5 },
+      { name: 'Balance', fuelFactor: 0.9, speed: 2.5 },
+      { name: 'Turbo',   fuelFactor: 1.8, speed: 4.0 },
+    ]},
+    { tier: 4, fuelCap: 800, modes: [
+      { name: 'Eco',     fuelFactor: 0.3, speed: 2.0 },
+      { name: 'Balance', fuelFactor: 0.6, speed: 3.5 },
+      { name: 'Turbo',   fuelFactor: 1.2, speed: 5.0 },
+    ]},
+  ],
+  // Olympus Propulsion (Mars) — turbo-optimized, best Turbo mode
+  olympus: [
+    TIER_1,
+    { tier: 2, fuelCap: 500, modes: [
+      { name: 'Eco',     fuelFactor: 1.0, speed: 1.1 },
+      { name: 'Balance', fuelFactor: 1.6, speed: 1.8 },
+      { name: 'Turbo',   fuelFactor: 2.4, speed: 3.5 },
+    ]},
+    { tier: 3, fuelCap: 650, modes: [
+      { name: 'Eco',     fuelFactor: 0.7, speed: 1.3 },
+      { name: 'Balance', fuelFactor: 1.0, speed: 2.3 },
+      { name: 'Turbo',   fuelFactor: 1.3, speed: 4.5 },
+    ]},
+    { tier: 4, fuelCap: 800, modes: [
+      { name: 'Eco',     fuelFactor: 0.4, speed: 1.8 },
+      { name: 'Balance', fuelFactor: 0.7, speed: 3.2 },
+      { name: 'Turbo',   fuelFactor: 0.8, speed: 5.5 },
+    ]},
+  ],
+  // Huygens Deepspace (Titan) — eco-optimized, best Eco mode
+  huygens: [
+    TIER_1,
+    { tier: 2, fuelCap: 500, modes: [
+      { name: 'Eco',     fuelFactor: 0.6, speed: 1.2 },
+      { name: 'Balance', fuelFactor: 1.6, speed: 1.8 },
+      { name: 'Turbo',   fuelFactor: 3.5, speed: 2.7 },
+    ]},
+    { tier: 3, fuelCap: 650, modes: [
+      { name: 'Eco',     fuelFactor: 0.4, speed: 1.8 },
+      { name: 'Balance', fuelFactor: 1.0, speed: 2.3 },
+      { name: 'Turbo',   fuelFactor: 2.2, speed: 3.5 },
+    ]},
+    { tier: 4, fuelCap: 800, modes: [
+      { name: 'Eco',     fuelFactor: 0.2, speed: 2.3 },
+      { name: 'Balance', fuelFactor: 0.7, speed: 3.2 },
+      { name: 'Turbo',   fuelFactor: 1.5, speed: 4.5 },
+    ]},
+  ],
+};
 
 // locations.ink: LocationData Name field (display names, in location-index order)
 const LOCATION_NAMES   = ['Earth', 'Luna', 'Mars', 'Ceres', 'Ganymede', 'Titan'];
@@ -582,8 +637,15 @@ function calcProfit(pay, fuelUnits, fuelPricePerUnit) {
   return pay - fuelUnits * fuelPricePerUnit;
 }
 
+// ── Helper to resolve the current canonical engine from manufacturer + tier ─
+
+function getCanonicalEngine() {
+  return ENGINES[MFG_KEYS[mfgIdx]][tierIdx];
+}
+
 // ── State ──────────────────────────────────────────────────────────────────
 
+let mfgIdx  = 0;
 let tierIdx = 0;
 let fromIdx = 0;
 let toIdx   = 2; // default Earth → Mars
@@ -597,10 +659,11 @@ function cloneEngine(e) {
   };
 }
 
-let activeEngine = cloneEngine(ENGINES[tierIdx]);
+let activeEngine = cloneEngine(getCanonicalEngine());
 
 // ── DOM Setup ─────────────────────────────────────────────────────────────
 
+const selMfg  = document.getElementById('sel-mfg');
 const selTier = document.getElementById('sel-tier');
 const selFrom = document.getElementById('sel-from');
 const selTo   = document.getElementById('sel-to');
@@ -618,7 +681,14 @@ LOCATION_DISPLAY.forEach((name, i) => {
   selTo.appendChild(optTo);
 });
 
-selTier.addEventListener('change', () => { tierIdx = +selTier.value; update(); });
+function updateMfgState() {
+  // Tier 1 is universal — disable manufacturer selector
+  selMfg.disabled = (tierIdx === 0);
+  selMfg.style.opacity = (tierIdx === 0) ? '0.5' : '1';
+}
+
+selMfg.addEventListener('change',  () => { mfgIdx  = +selMfg.value;  update(); });
+selTier.addEventListener('change', () => { tierIdx = +selTier.value; updateMfgState(); update(); });
 selFrom.addEventListener('change', () => { fromIdx = +selFrom.value; update(); });
 selTo.addEventListener('change',   () => { toIdx   = +selTo.value;   update(); });
 
@@ -983,7 +1053,7 @@ function editorValuesFromEngine(engine) {
 }
 
 function applyEditorToActiveEngine() {
-  const canonical = ENGINES[tierIdx];
+  const canonical = getCanonicalEngine();
   activeEngine.fuelCap         = Math.max(1, +edInputs.fuelCap.value  || canonical.fuelCap);
   activeEngine.modes[0].fuelFactor = Math.max(0.01, +edInputs.ecoFf.value   || canonical.modes[0].fuelFactor);
   activeEngine.modes[1].fuelFactor = Math.max(0.01, +edInputs.balFf.value   || canonical.modes[1].fuelFactor);
@@ -994,7 +1064,7 @@ function applyEditorToActiveEngine() {
 }
 
 function updateModifiedHighlights() {
-  const canonical = ENGINES[tierIdx];
+  const canonical = getCanonicalEngine();
   const fields = [
     [edInputs.fuelCap,  activeEngine.fuelCap,         canonical.fuelCap],
     [edInputs.ecoFf,    activeEngine.modes[0].fuelFactor, canonical.modes[0].fuelFactor],
@@ -1023,7 +1093,7 @@ Object.values(edInputs).forEach(input => {
 });
 
 btnReset.addEventListener('click', () => {
-  activeEngine = cloneEngine(ENGINES[tierIdx]);
+  activeEngine = cloneEngine(getCanonicalEngine());
   editorValuesFromEngine(activeEngine);
   updateModifiedHighlights();
   drawChart();
@@ -1032,7 +1102,8 @@ btnReset.addEventListener('click', () => {
 // ── Update & Init ──────────────────────────────────────────────────────────
 
 function update() {
-  activeEngine = cloneEngine(ENGINES[tierIdx]);
+  updateMfgState();
+  activeEngine = cloneEngine(getCanonicalEngine());
   editorValuesFromEngine(activeEngine);
   updateModifiedHighlights();
   drawChart();

--- a/space-truckers.ink
+++ b/space-truckers.ink
@@ -11,6 +11,9 @@ INCLUDE functions.ink
 VAR PlayerBankBalance = 200
 VAR PayRate = 3
 
+LIST Manufacturers = Kepler, Olympus, Huygens
+
+VAR ShipManufacturer = Kepler
 VAR ShipEngineTier = 1
 VAR ShipFuelCapacity = 300
 VAR ShipFuel = 225
@@ -23,19 +26,67 @@ LIST EngineStats = FuelCap, EcoFuel, EcoSpeed, BalFuel, BalSpeed, TurboFuel, Tur
 /*
 
     Engine Database
-    Returns the requested stat for a given engine tier.
+    Returns the requested stat for a given manufacturer and engine tier.
+
+    Manufacturers:
+      Kepler  (Earth)  — balanced, best Balance mode
+      Olympus (Mars)   — turbo-optimized, best Turbo mode
+      Huygens (Titan)  — eco-optimized, best Eco mode
+
+    Tier 1 is a universal starter engine shared by all manufacturers.
 
 */
-=== function EngineData(tier, stat)
+=== function EngineData(mfg, tier, stat)
+{ tier == 1:
+    //                       Cap   EcoFF EcoSpd BalFF BalSpd TurboFF TurboSpd
+    ~ return engine_db(stat, 300,  1.1,  1.0,   1.8,  1.5,   4.0,    2.5)
+}
+{ mfg:
+- Kepler:  ~ return KeplerData(tier, stat)
+- Olympus: ~ return OlympusData(tier, stat)
+- Huygens: ~ return HuygensData(tier, stat)
+}
+
+/*
+
+    Kepler Drive Systems (Earth) — Balanced
+    Best Balance mode at every tier. Solid all-rounder.
+
+*/
+=== function KeplerData(tier, stat)
 { tier:
-- 1:
-    ~ return engine_db(stat, 300, 1.1, 1.0, 1.8, 1.5, 4.0, 2.5)
-- 2:
-    ~ return engine_db(stat, 500, 0.8, 1.0, 1.5, 2.0, 3.0, 3.0)
-- 3:
-    ~ return engine_db(stat, 650, 0.5, 1.5, 0.9, 2.5, 1.8, 4.0)
-- 4:
-    ~ return engine_db(stat, 800, 0.3, 2.0, 0.6, 3.5, 1.2, 5.0)
+//                           Cap   EcoFF EcoSpd BalFF BalSpd TurboFF TurboSpd
+- 2: ~ return engine_db(stat, 500, 0.8,  1.1,   1.5,  2.0,   3.0,    3.0)
+- 3: ~ return engine_db(stat, 650, 0.5,  1.5,   0.9,  2.5,   1.8,    4.0)
+- 4: ~ return engine_db(stat, 800, 0.3,  2.0,   0.6,  3.5,   1.2,    5.0)
+}
+
+/*
+
+    Olympus Propulsion (Mars) — Turbo-optimized
+    Best Turbo mode. Eco mode is weaker but still improves each tier.
+
+*/
+=== function OlympusData(tier, stat)
+{ tier:
+//                           Cap   EcoFF EcoSpd BalFF BalSpd TurboFF TurboSpd
+- 2: ~ return engine_db(stat, 500, 1.0,  1.1,   1.6,  1.8,   2.4,    3.5)
+- 3: ~ return engine_db(stat, 650, 0.7,  1.3,   1.0,  2.3,   1.3,    4.5)
+- 4: ~ return engine_db(stat, 800, 0.4,  1.8,   0.7,  3.2,   0.8,    5.5)
+}
+
+/*
+
+    Huygens Deepspace (Titan) — Eco-optimized
+    Best Eco mode. Turbo mode is weaker but still improves each tier.
+
+*/
+=== function HuygensData(tier, stat)
+{ tier:
+//                           Cap   EcoFF EcoSpd BalFF BalSpd TurboFF TurboSpd
+- 2: ~ return engine_db(stat, 500, 0.6,  1.2,   1.6,  1.8,   3.5,    2.7)
+- 3: ~ return engine_db(stat, 650, 0.4,  1.8,   1.0,  2.3,   2.2,    3.5)
+- 4: ~ return engine_db(stat, 800, 0.2,  2.3,   0.7,  3.2,   1.5,    4.5)
 }
 
 /*
@@ -56,4 +107,5 @@ LIST EngineStats = FuelCap, EcoFuel, EcoSpeed, BalFuel, BalSpeed, TurboFuel, Tur
 }
 
 // TODO: implement engine upgrade purchase UI
-// To upgrade: ~ ShipEngineTier++; ~ ShipFuelCapacity = EngineData(ShipEngineTier, FuelCap)
+// To upgrade: ~ ShipManufacturer = Olympus; ~ ShipEngineTier = 2; ~ ShipFuelCapacity = EngineData(ShipManufacturer, ShipEngineTier, FuelCap)
+// Availability: Kepler at Earth/Luna, Olympus at Mars, Huygens at Ganymede/Titan, all at Ceres

--- a/tests/unit/engine.test.js
+++ b/tests/unit/engine.test.js
@@ -1,12 +1,13 @@
 /**
- * Unit tests for EngineData — verifies all 4 engine tiers return the correct
- * stats from the database defined in space-truckers.ink.
+ * Unit tests for EngineData — verifies all engine tiers across 3 manufacturers
+ * return the correct stats from the database defined in space-truckers.ink.
  *
- * Source of truth:
- *   Tier 1: engine_db(stat, 300, 1.1, 1.0, 1.8, 1.5, 4.0, 2.5)
- *   Tier 2: engine_db(stat, 500, 0.8, 1.0, 1.5, 2.0, 3.0, 3.0)
- *   Tier 3: engine_db(stat, 650, 0.5, 1.5, 0.9, 2.5, 1.8, 4.0)
- *   Tier 4: engine_db(stat, 800, 0.3, 2.0, 0.6, 3.5, 1.2, 5.0)
+ * Manufacturers:
+ *   Kepler  (Earth)  — balanced, best Balance mode
+ *   Olympus (Mars)   — turbo-optimized, best Turbo mode
+ *   Huygens (Titan)  — eco-optimized, best Eco mode
+ *
+ * Tier 1 is a universal starter engine shared by all manufacturers.
  */
 
 import { describe, it, expect, beforeAll } from "vitest";
@@ -18,48 +19,210 @@ beforeAll(() => {
   story = createStory();
 });
 
-function engine(tier, stat) {
-  return story.EvaluateFunction("EngineData", [tier, L(story, `EngineStats.${stat}`)]);
+function engine(mfg, tier, stat) {
+  return story.EvaluateFunction("EngineData", [
+    L(story, `Manufacturers.${mfg}`),
+    tier,
+    L(story, `EngineStats.${stat}`),
+  ]);
 }
 
+// ── Stat verification ─────────────────────────────────────────────────────
+
 describe("EngineData", () => {
-  describe("Tier 1", () => {
-    it("FuelCap = 300", () => expect(engine(1, "FuelCap")).toBe(300));
-    it("EcoFuel = 1.1", () => expect(engine(1, "EcoFuel")).toBeCloseTo(1.1));
-    it("EcoSpeed = 1.0", () => expect(engine(1, "EcoSpeed")).toBeCloseTo(1.0));
-    it("BalFuel = 1.8", () => expect(engine(1, "BalFuel")).toBeCloseTo(1.8));
-    it("BalSpeed = 1.5", () => expect(engine(1, "BalSpeed")).toBeCloseTo(1.5));
-    it("TurboFuel = 4.0", () => expect(engine(1, "TurboFuel")).toBeCloseTo(4.0));
-    it("TurboSpeed = 2.5", () => expect(engine(1, "TurboSpeed")).toBeCloseTo(2.5));
+  describe("Tier 1 (universal)", () => {
+    it("FuelCap = 300", () => expect(engine("Kepler", 1, "FuelCap")).toBe(300));
+    it("EcoFuel = 1.1", () => expect(engine("Kepler", 1, "EcoFuel")).toBeCloseTo(1.1));
+    it("EcoSpeed = 1.0", () => expect(engine("Kepler", 1, "EcoSpeed")).toBeCloseTo(1.0));
+    it("BalFuel = 1.8", () => expect(engine("Kepler", 1, "BalFuel")).toBeCloseTo(1.8));
+    it("BalSpeed = 1.5", () => expect(engine("Kepler", 1, "BalSpeed")).toBeCloseTo(1.5));
+    it("TurboFuel = 4.0", () => expect(engine("Kepler", 1, "TurboFuel")).toBeCloseTo(4.0));
+    it("TurboSpeed = 2.5", () => expect(engine("Kepler", 1, "TurboSpeed")).toBeCloseTo(2.5));
+
+    it("is the same for all manufacturers", () => {
+      const stats = ["FuelCap", "EcoFuel", "EcoSpeed", "BalFuel", "BalSpeed", "TurboFuel", "TurboSpeed"];
+      for (const stat of stats) {
+        expect(engine("Olympus", 1, stat)).toBeCloseTo(engine("Kepler", 1, stat));
+        expect(engine("Huygens", 1, stat)).toBeCloseTo(engine("Kepler", 1, stat));
+      }
+    });
   });
 
-  describe("Tier 2", () => {
-    it("FuelCap = 500", () => expect(engine(2, "FuelCap")).toBe(500));
-    it("EcoFuel = 0.8", () => expect(engine(2, "EcoFuel")).toBeCloseTo(0.8));
-    it("EcoSpeed = 1.0", () => expect(engine(2, "EcoSpeed")).toBeCloseTo(1.0));
-    it("BalFuel = 1.5", () => expect(engine(2, "BalFuel")).toBeCloseTo(1.5));
-    it("BalSpeed = 2.0", () => expect(engine(2, "BalSpeed")).toBeCloseTo(2.0));
-    it("TurboFuel = 3.0", () => expect(engine(2, "TurboFuel")).toBeCloseTo(3.0));
-    it("TurboSpeed = 3.0", () => expect(engine(2, "TurboSpeed")).toBeCloseTo(3.0));
+  describe("Kepler (Earth — balanced)", () => {
+    it("T2 FuelCap = 500", () => expect(engine("Kepler", 2, "FuelCap")).toBe(500));
+    it("T2 EcoFuel = 0.8", () => expect(engine("Kepler", 2, "EcoFuel")).toBeCloseTo(0.8));
+    it("T2 EcoSpeed = 1.1", () => expect(engine("Kepler", 2, "EcoSpeed")).toBeCloseTo(1.1));
+    it("T2 BalFuel = 1.5", () => expect(engine("Kepler", 2, "BalFuel")).toBeCloseTo(1.5));
+    it("T2 BalSpeed = 2.0", () => expect(engine("Kepler", 2, "BalSpeed")).toBeCloseTo(2.0));
+    it("T2 TurboFuel = 3.0", () => expect(engine("Kepler", 2, "TurboFuel")).toBeCloseTo(3.0));
+    it("T2 TurboSpeed = 3.0", () => expect(engine("Kepler", 2, "TurboSpeed")).toBeCloseTo(3.0));
+
+    it("T3 FuelCap = 650", () => expect(engine("Kepler", 3, "FuelCap")).toBe(650));
+    it("T3 EcoFuel = 0.5", () => expect(engine("Kepler", 3, "EcoFuel")).toBeCloseTo(0.5));
+    it("T3 EcoSpeed = 1.5", () => expect(engine("Kepler", 3, "EcoSpeed")).toBeCloseTo(1.5));
+    it("T3 BalFuel = 0.9", () => expect(engine("Kepler", 3, "BalFuel")).toBeCloseTo(0.9));
+    it("T3 BalSpeed = 2.5", () => expect(engine("Kepler", 3, "BalSpeed")).toBeCloseTo(2.5));
+    it("T3 TurboFuel = 1.8", () => expect(engine("Kepler", 3, "TurboFuel")).toBeCloseTo(1.8));
+    it("T3 TurboSpeed = 4.0", () => expect(engine("Kepler", 3, "TurboSpeed")).toBeCloseTo(4.0));
+
+    it("T4 FuelCap = 800", () => expect(engine("Kepler", 4, "FuelCap")).toBe(800));
+    it("T4 EcoFuel = 0.3", () => expect(engine("Kepler", 4, "EcoFuel")).toBeCloseTo(0.3));
+    it("T4 EcoSpeed = 2.0", () => expect(engine("Kepler", 4, "EcoSpeed")).toBeCloseTo(2.0));
+    it("T4 BalFuel = 0.6", () => expect(engine("Kepler", 4, "BalFuel")).toBeCloseTo(0.6));
+    it("T4 BalSpeed = 3.5", () => expect(engine("Kepler", 4, "BalSpeed")).toBeCloseTo(3.5));
+    it("T4 TurboFuel = 1.2", () => expect(engine("Kepler", 4, "TurboFuel")).toBeCloseTo(1.2));
+    it("T4 TurboSpeed = 5.0", () => expect(engine("Kepler", 4, "TurboSpeed")).toBeCloseTo(5.0));
   });
 
-  describe("Tier 3", () => {
-    it("FuelCap = 650", () => expect(engine(3, "FuelCap")).toBe(650));
-    it("EcoFuel = 0.5", () => expect(engine(3, "EcoFuel")).toBeCloseTo(0.5));
-    it("EcoSpeed = 1.5", () => expect(engine(3, "EcoSpeed")).toBeCloseTo(1.5));
-    it("BalFuel = 0.9", () => expect(engine(3, "BalFuel")).toBeCloseTo(0.9));
-    it("BalSpeed = 2.5", () => expect(engine(3, "BalSpeed")).toBeCloseTo(2.5));
-    it("TurboFuel = 1.8", () => expect(engine(3, "TurboFuel")).toBeCloseTo(1.8));
-    it("TurboSpeed = 4.0", () => expect(engine(3, "TurboSpeed")).toBeCloseTo(4.0));
+  describe("Olympus (Mars — turbo-optimized)", () => {
+    it("T2 FuelCap = 500", () => expect(engine("Olympus", 2, "FuelCap")).toBe(500));
+    it("T2 EcoFuel = 1.0", () => expect(engine("Olympus", 2, "EcoFuel")).toBeCloseTo(1.0));
+    it("T2 EcoSpeed = 1.1", () => expect(engine("Olympus", 2, "EcoSpeed")).toBeCloseTo(1.1));
+    it("T2 BalFuel = 1.6", () => expect(engine("Olympus", 2, "BalFuel")).toBeCloseTo(1.6));
+    it("T2 BalSpeed = 1.8", () => expect(engine("Olympus", 2, "BalSpeed")).toBeCloseTo(1.8));
+    it("T2 TurboFuel = 2.4", () => expect(engine("Olympus", 2, "TurboFuel")).toBeCloseTo(2.4));
+    it("T2 TurboSpeed = 3.5", () => expect(engine("Olympus", 2, "TurboSpeed")).toBeCloseTo(3.5));
+
+    it("T3 FuelCap = 650", () => expect(engine("Olympus", 3, "FuelCap")).toBe(650));
+    it("T3 EcoFuel = 0.7", () => expect(engine("Olympus", 3, "EcoFuel")).toBeCloseTo(0.7));
+    it("T3 EcoSpeed = 1.3", () => expect(engine("Olympus", 3, "EcoSpeed")).toBeCloseTo(1.3));
+    it("T3 BalFuel = 1.0", () => expect(engine("Olympus", 3, "BalFuel")).toBeCloseTo(1.0));
+    it("T3 BalSpeed = 2.3", () => expect(engine("Olympus", 3, "BalSpeed")).toBeCloseTo(2.3));
+    it("T3 TurboFuel = 1.3", () => expect(engine("Olympus", 3, "TurboFuel")).toBeCloseTo(1.3));
+    it("T3 TurboSpeed = 4.5", () => expect(engine("Olympus", 3, "TurboSpeed")).toBeCloseTo(4.5));
+
+    it("T4 FuelCap = 800", () => expect(engine("Olympus", 4, "FuelCap")).toBe(800));
+    it("T4 EcoFuel = 0.4", () => expect(engine("Olympus", 4, "EcoFuel")).toBeCloseTo(0.4));
+    it("T4 EcoSpeed = 1.8", () => expect(engine("Olympus", 4, "EcoSpeed")).toBeCloseTo(1.8));
+    it("T4 BalFuel = 0.7", () => expect(engine("Olympus", 4, "BalFuel")).toBeCloseTo(0.7));
+    it("T4 BalSpeed = 3.2", () => expect(engine("Olympus", 4, "BalSpeed")).toBeCloseTo(3.2));
+    it("T4 TurboFuel = 0.8", () => expect(engine("Olympus", 4, "TurboFuel")).toBeCloseTo(0.8));
+    it("T4 TurboSpeed = 5.5", () => expect(engine("Olympus", 4, "TurboSpeed")).toBeCloseTo(5.5));
   });
 
-  describe("Tier 4", () => {
-    it("FuelCap = 800", () => expect(engine(4, "FuelCap")).toBe(800));
-    it("EcoFuel = 0.3", () => expect(engine(4, "EcoFuel")).toBeCloseTo(0.3));
-    it("EcoSpeed = 2.0", () => expect(engine(4, "EcoSpeed")).toBeCloseTo(2.0));
-    it("BalFuel = 0.6", () => expect(engine(4, "BalFuel")).toBeCloseTo(0.6));
-    it("BalSpeed = 3.5", () => expect(engine(4, "BalSpeed")).toBeCloseTo(3.5));
-    it("TurboFuel = 1.2", () => expect(engine(4, "TurboFuel")).toBeCloseTo(1.2));
-    it("TurboSpeed = 5.0", () => expect(engine(4, "TurboSpeed")).toBeCloseTo(5.0));
+  describe("Huygens (Titan — eco-optimized)", () => {
+    it("T2 FuelCap = 500", () => expect(engine("Huygens", 2, "FuelCap")).toBe(500));
+    it("T2 EcoFuel = 0.6", () => expect(engine("Huygens", 2, "EcoFuel")).toBeCloseTo(0.6));
+    it("T2 EcoSpeed = 1.2", () => expect(engine("Huygens", 2, "EcoSpeed")).toBeCloseTo(1.2));
+    it("T2 BalFuel = 1.6", () => expect(engine("Huygens", 2, "BalFuel")).toBeCloseTo(1.6));
+    it("T2 BalSpeed = 1.8", () => expect(engine("Huygens", 2, "BalSpeed")).toBeCloseTo(1.8));
+    it("T2 TurboFuel = 3.5", () => expect(engine("Huygens", 2, "TurboFuel")).toBeCloseTo(3.5));
+    it("T2 TurboSpeed = 2.7", () => expect(engine("Huygens", 2, "TurboSpeed")).toBeCloseTo(2.7));
+
+    it("T3 FuelCap = 650", () => expect(engine("Huygens", 3, "FuelCap")).toBe(650));
+    it("T3 EcoFuel = 0.4", () => expect(engine("Huygens", 3, "EcoFuel")).toBeCloseTo(0.4));
+    it("T3 EcoSpeed = 1.8", () => expect(engine("Huygens", 3, "EcoSpeed")).toBeCloseTo(1.8));
+    it("T3 BalFuel = 1.0", () => expect(engine("Huygens", 3, "BalFuel")).toBeCloseTo(1.0));
+    it("T3 BalSpeed = 2.3", () => expect(engine("Huygens", 3, "BalSpeed")).toBeCloseTo(2.3));
+    it("T3 TurboFuel = 2.2", () => expect(engine("Huygens", 3, "TurboFuel")).toBeCloseTo(2.2));
+    it("T3 TurboSpeed = 3.5", () => expect(engine("Huygens", 3, "TurboSpeed")).toBeCloseTo(3.5));
+
+    it("T4 FuelCap = 800", () => expect(engine("Huygens", 4, "FuelCap")).toBe(800));
+    it("T4 EcoFuel = 0.2", () => expect(engine("Huygens", 4, "EcoFuel")).toBeCloseTo(0.2));
+    it("T4 EcoSpeed = 2.3", () => expect(engine("Huygens", 4, "EcoSpeed")).toBeCloseTo(2.3));
+    it("T4 BalFuel = 0.7", () => expect(engine("Huygens", 4, "BalFuel")).toBeCloseTo(0.7));
+    it("T4 BalSpeed = 3.2", () => expect(engine("Huygens", 4, "BalSpeed")).toBeCloseTo(3.2));
+    it("T4 TurboFuel = 1.5", () => expect(engine("Huygens", 4, "TurboFuel")).toBeCloseTo(1.5));
+    it("T4 TurboSpeed = 4.5", () => expect(engine("Huygens", 4, "TurboSpeed")).toBeCloseTo(4.5));
+  });
+
+  // ── Tier progression (monotonicity) ───────────────────────────────────────
+
+  describe("Tier progression", () => {
+    const manufacturers = ["Kepler", "Olympus", "Huygens"];
+    const fuelStats = ["EcoFuel", "BalFuel", "TurboFuel"];
+    const speedStats = ["EcoSpeed", "BalSpeed", "TurboSpeed"];
+
+    for (const mfg of manufacturers) {
+      describe(mfg, () => {
+        for (let tier = 2; tier <= 4; tier++) {
+          describe(`T${tier - 1} → T${tier}`, () => {
+            it("FuelCap increases", () => {
+              expect(engine(mfg, tier, "FuelCap")).toBeGreaterThanOrEqual(
+                engine(mfg, tier - 1, "FuelCap"),
+              );
+            });
+
+            for (const stat of fuelStats) {
+              it(`${stat} improves (lower)`, () => {
+                expect(engine(mfg, tier, stat)).toBeLessThan(
+                  engine(mfg, tier - 1, stat),
+                );
+              });
+            }
+
+            for (const stat of speedStats) {
+              it(`${stat} improves (higher)`, () => {
+                expect(engine(mfg, tier, stat)).toBeGreaterThan(
+                  engine(mfg, tier - 1, stat),
+                );
+              });
+            }
+          });
+        }
+      });
+    }
+  });
+
+  // ── Cross-manufacturer comparisons ────────────────────────────────────────
+
+  describe("Manufacturer comparisons", () => {
+    for (let tier = 2; tier <= 4; tier++) {
+      describe(`Tier ${tier}`, () => {
+        it("Kepler has best BalFuel (lowest)", () => {
+          expect(engine("Kepler", tier, "BalFuel")).toBeLessThanOrEqual(
+            engine("Olympus", tier, "BalFuel"),
+          );
+          expect(engine("Kepler", tier, "BalFuel")).toBeLessThanOrEqual(
+            engine("Huygens", tier, "BalFuel"),
+          );
+        });
+
+        it("Kepler has best BalSpeed (highest)", () => {
+          expect(engine("Kepler", tier, "BalSpeed")).toBeGreaterThanOrEqual(
+            engine("Olympus", tier, "BalSpeed"),
+          );
+          expect(engine("Kepler", tier, "BalSpeed")).toBeGreaterThanOrEqual(
+            engine("Huygens", tier, "BalSpeed"),
+          );
+        });
+
+        it("Olympus has best TurboFuel (lowest)", () => {
+          expect(engine("Olympus", tier, "TurboFuel")).toBeLessThan(
+            engine("Kepler", tier, "TurboFuel"),
+          );
+          expect(engine("Olympus", tier, "TurboFuel")).toBeLessThan(
+            engine("Huygens", tier, "TurboFuel"),
+          );
+        });
+
+        it("Olympus has best TurboSpeed (highest)", () => {
+          expect(engine("Olympus", tier, "TurboSpeed")).toBeGreaterThan(
+            engine("Kepler", tier, "TurboSpeed"),
+          );
+          expect(engine("Olympus", tier, "TurboSpeed")).toBeGreaterThan(
+            engine("Huygens", tier, "TurboSpeed"),
+          );
+        });
+
+        it("Huygens has best EcoFuel (lowest)", () => {
+          expect(engine("Huygens", tier, "EcoFuel")).toBeLessThan(
+            engine("Kepler", tier, "EcoFuel"),
+          );
+          expect(engine("Huygens", tier, "EcoFuel")).toBeLessThan(
+            engine("Olympus", tier, "EcoFuel"),
+          );
+        });
+
+        it("Huygens has best EcoSpeed (highest)", () => {
+          expect(engine("Huygens", tier, "EcoSpeed")).toBeGreaterThan(
+            engine("Kepler", tier, "EcoSpeed"),
+          );
+          expect(engine("Huygens", tier, "EcoSpeed")).toBeGreaterThan(
+            engine("Olympus", tier, "EcoSpeed"),
+          );
+        });
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the linear 4-tier engine ladder with a 3-manufacturer system, giving players a meaningful choice at each upgrade rather than a single path
- Each manufacturer specializes in a different flight mode while still improving in all modes each tier — no punishing lock-in
- Tier 1 remains a universal starter; manufacturers become available at tier 2

**Manufacturers:**
| Name | Location | Specialty |
|------|----------|-----------|
| Kepler Drive Systems | Earth / Luna | Best Balance mode at every tier |
| Olympus Propulsion | Mars | Best Turbo mode (~25-33% better fuel factor) |
| Huygens Deepspace | Ganymede / Titan / Ceres | Best Eco mode (~25-33% better fuel factor) |

Ceres stocks all three manufacturers, making it a valuable hub for comparison shopping.

## Changes

- **`space-truckers.ink`** — `LIST Manufacturers`, `VAR ShipManufacturer = Kepler`, `EngineData(tier, stat)` → `EngineData(mfg, tier, stat)` with `KeplerData`/`OlympusData`/`HuygensData` helpers. Bumped Kepler T2 EcoSpeed 1.0→1.1 for strict monotonicity.
- **`port.ink`, `cargo.ink`** — Updated all `EngineData` callers to pass `ShipManufacturer` as first arg.
- **`simulator.html`** — `ENGINES` restructured to manufacturer-keyed object with shared `TIER_1`. Added Manufacturer dropdown (disables at tier 1). Engine lookups via `getCanonicalEngine()`.
- **`tests/unit/engine.test.js`** — Expanded 28 → 152 assertions: per-manufacturer stat verification, tier 1 universality, monotonicity across all tiers, cross-manufacturer specialist comparisons.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm test` — 388 tests pass (152 in engine.test.js)
- [ ] Open `simulator.html` in browser — verify Manufacturer dropdown, chart updates correctly per manufacturer/tier, editor reset works

🤖 Generated with [Claude Code](https://claude.com/claude-code)