### PR TITLE
Add player stats and transit task system

### DIFF
--- a/cargo.ink
+++ b/cargo.ink
@@ -1573,3 +1573,25 @@ LIST AllCargo =
     ~ return CargoData(item, Mass) + total_mass(items)
 }
 ~ return 0
+
+/*
+
+    Count Paperwork Chunks
+    Hybrid model: 1 base flight log chunk + 1 extra per cargo item
+    that has any special flag (Express, Hazardous, or Passengers).
+    A cargo item with multiple flags still only adds 1 chunk.
+
+*/
+=== function count_paperwork_chunks(items)
+~ return 1 + _count_flagged_cargo(items)
+
+=== function _count_flagged_cargo(items)
+~ temp item = pop(items)
+{ item:
+    { CargoData(item, Express) or CargoData(item, Hazardous) or CargoData(item, Passengers):
+        ~ return 1 + _count_flagged_cargo(items)
+    - else:
+        ~ return _count_flagged_cargo(items)
+    }
+}
+~ return 0

--- a/port.ink
+++ b/port.ink
@@ -8,8 +8,16 @@ VAR PortCargo = ()
 === arrive_in_port(port)
 ~ here = port
 ~ PortCargo = get_available_cargo(port, 5)
+~ ShipCondition = 100
 
 Welcome to {LocationData(port, Name)}!
+
+// Paperwork settlement
+{ PaperworkDone < PaperworkTotal:
+    ~ temp missing = PaperworkTotal - PaperworkDone
+    You didn't complete all your paperwork. The port authority hits you with a customs fine for {missing} missing document{missing > 1:s}.
+    // TODO: calculate and apply actual fine amount
+}
 
 - (port_opts)
 + [Load cargo]
@@ -237,21 +245,21 @@ The current unit cost of fuel is {price} €. Your fuel gauge reads {ShipFuel}/{
 You have {ShipFuel} fuel, and a total mass of {total_mass(ShipCargo)}t.
 + {can_use_flight_mode(has_express, ShipFuel, slow_cost)}
     [Economy Mode ({slow_cost} fuel, {slow_time} days)]
-    -> transit(to, slow_cost, slow_time)
+    -> transit(to, slow_cost, slow_time, Eco)
 + {not can_use_flight_mode(has_express, ShipFuel, slow_cost)}
     [Economy Mode ({slow_cost} fuel, {slow_time} days) #UNCLICKABLE]
     { has_express: Express cargo requires Turbo mode. - else: You do not have enough fuel to use economy mode. }
     -> port_opts
 + {can_use_flight_mode(has_express, ShipFuel, norm_cost)}
     [Balance Mode ({norm_cost} fuel, {norm_time} days)]
-    -> transit(to, norm_cost, norm_time)
+    -> transit(to, norm_cost, norm_time, Bal)
 + {not can_use_flight_mode(has_express, ShipFuel, norm_cost)}
     [Balance Mode ({norm_cost} fuel, {norm_time} days) #UNCLICKABLE]
     { has_express: Express cargo requires Turbo mode. - else: You do not have enough fuel to use balance mode. }
     -> port_opts
 + {can_use_flight_mode(blocks_turbo, ShipFuel, fast_cost)}
     [Turbo Mode ({fast_cost} fuel, {fast_time} days)]
-    -> transit(to, fast_cost, fast_time)
+    -> transit(to, fast_cost, fast_time, Turbo)
 + {not can_use_flight_mode(blocks_turbo, ShipFuel, fast_cost)}
     [Turbo Mode ({fast_cost} fuel, {fast_time} days) #UNCLICKABLE]
     { blocks_turbo: Fragile or passenger cargo cannot use Turbo mode. - else: You do not have enough fuel to use turbo mode. }

--- a/ship.ink
+++ b/ship.ink
@@ -1,29 +1,33 @@
-TODO ship flip is a required task at the halfway point
-TODO paperwork is a required task for every flight
-TODO ship modules degrade and need maintenance
-TODO your stats affect your job performance
-TODO stamina reduced by work, regained by sleep/eat
-TODO misery increased by work, reduced by play, affected by cleanliness
-TODO ship modules improve stat gain (better meals, maintenance, etc)
-TODO ship modules have a percentage likelihood of breaking every day, based on condition
-TODO you have a chance to fail tasks based on your condition (by not sleeping, you can do more, but you might fuck it up after awhile)
+// TODO: ship modules degrade and need maintenance
+// TODO: Fatigue affects task success (chance to fail tasks when overtired)
+// TODO: ship flip fuel penalty for delay (each day past midpoint = +5% trip fuel)
+// TODO: sloppy flip (overtired) fuel penalty
+// TODO: navigation check skip penalty (extra fuel on arrival)
+// TODO: contextual ship maintenance variety (drain lines, laundry, secure items, etc.)
+// TODO: passenger events when carrying passenger cargo
+// TODO: random events (micrometeorite, power surge, cargo shift, distress signal, etc.)
 
 VAR ShipClock = 0
 VAR ShipDestination = Transit
 VAR AP = 6
 VAR ActionPointsMax = 6
-VAR AwakeDuration = 0
 
 /*
 
     Transit
 
 */
-=== transit(destination, fuel_cost, duration)
+=== transit(destination, fuel_cost, duration, mode)
 ~ here = Transit
 ~ ShipDestination = destination
 ~ ShipFuel -= fuel_cost
 ~ ShipClock = duration
+~ TripDuration = duration
+~ TripDay = 0
+~ FlipDone = false
+~ FlightMode = mode
+~ PaperworkTotal = count_paperwork_chunks(ShipCargo)
+~ PaperworkDone = 0
 Flying to {LocationData(destination, Name)} for {duration} days…
 -> ship_options
 
@@ -33,44 +37,195 @@ Flying to {LocationData(destination, Name)} for {duration} days…
 
 */
 = ship_options
-{is_overtired(): If you don't get some sleep soon, you'll start making mistakes.}
+{is_overtired(): You're exhausted. Your hands are shaking.}
 <center><em><small>{ShipClock} days to {LocationData(ShipDestination, Name)} / {AP} AP remaining</small></em></center>
 - (ship_opts)
-+ [Short Task (1 AP)]
-    -> pass_time(1)
-+ [Long Task (2 AP)]
-    -> pass_time(2)
-+ {can_sleep()} [Nap (1 AP)]
-    -> sleep(1)
-+ {can_sleep()} [Sleep (2 AP)]
+
+// No AP checks needed — the AP system allows borrowing from the next day
+// (negative AP rolls over via next_day). On the final day, any negative
+// rollover is harmlessly discarded on arrival.
+
+// P1: Ship flip (at midpoint, if not done)
++ {not FlipDone and TripDay >= TripDuration / 2}
+    [Execute ship flip (1 AP)]
+    -> do_flip
+
+// P2: Engine maintenance (when condition < 80%)
++ {EngineCondition < 80}
+    [Engine maintenance (2 AP)]
+    -> do_engine_maintenance
+
+// P2: Sleep (when very fatigued)
++ {Fatigue >= 70}
+    [Sleep (2 AP)]
     -> sleep(2)
+
+// P3: Paperwork (when chunks remain)
++ {PaperworkDone < PaperworkTotal}
+    [File paperwork — {PaperworkDone}/{PaperworkTotal} (1 AP)]
+    -> do_paperwork
+
+// P3: Navigation check (appears every 3 days)
++ {TripDay > 0 and TripDay mod 3 == 0}
+    [Navigation check (1 AP)]
+    -> do_nav_check
+
+// P3: Ship maintenance (when condition < 80%)
++ {ShipCondition < 80}
+    [Clean air filters (1 AP)]
+    -> do_ship_maintenance
+
+// P4: Cooking
++ [Heat up rations (1 AP)]
+    -> do_eat_rations
+
+// P4: Recreation
++ [Watch a movie (2 AP)]
+    -> do_recreation(2, 15)
+
++ [Quick workout (1 AP)]
+    -> do_recreation(1, 8)
+
+// P4: Nap (moderate fatigue)
++ {Fatigue >= 30}
+    [Nap (1 AP)]
+    -> sleep(1)
+
+// P4: Sleep (available when fatigued enough, but not yet urgent)
++ {Fatigue >= 40 and Fatigue < 70}
+    [Sleep (2 AP)]
+    -> sleep(2)
+
 - -> END
 
 /*
 
+    Ship Flip
+    Required once per trip at the midpoint. The ship rotates 180 degrees
+    to begin deceleration.
+
+*/
+= do_flip
+~ FlipDone = true
+{ is_overtired():
+    Your hands tremble on the controls as you initiate the flip sequence. The ship groans through the rotation — not your cleanest work.
+    // TODO: track fuel penalty for sloppy flip
+- else:
+    You initiate the flip sequence. The stars wheel past the viewport as the ship rotates 180 degrees. Engines now pointing forward for deceleration. Textbook.
+}
+-> pass_time(1)
+
+/*
+
+    Paperwork
+    File one chunk of customs documentation. Chunks are calculated at
+    departure: 1 base + 1 per special-flagged cargo item.
+
+*/
+= do_paperwork
+~ PaperworkDone++
+{ PaperworkDone >= PaperworkTotal:
+    You file the last of the paperwork. All customs documentation is in order.
+- else:
+    You work through a stack of customs forms and cargo manifests. {PaperworkTotal - PaperworkDone} chunks remaining.
+}
+-> pass_time(1)
+
+/*
+
+    Navigation Check
+    Review the flight trajectory and make course corrections.
+
+*/
+= do_nav_check
+You review the flight trajectory and make minor course corrections. Everything's on track.
+// TODO: track nav checks completed; missed checks add fuel penalty at arrival
+-> pass_time(1)
+
+/*
+
+    Engine Maintenance
+    Restore some engine condition. Costs 2 AP (1 AP with Basic Toolkit module).
+
+*/
+= do_engine_maintenance
+~ EngineCondition = MIN(EngineCondition + 15, 100)
+You run diagnostics and tune the engine. Condition improved to {EngineCondition}%.
+-> pass_time(2)
+
+/*
+
+    Ship Maintenance
+    Restore ship condition. Currently only air filters; future versions
+    will select contextually from a pool of maintenance tasks.
+
+*/
+= do_ship_maintenance
+~ ShipCondition = MIN(ShipCondition + 12, 100)
+You swap out the air filters and run a purge cycle. The ship smells noticeably fresher.
+-> pass_time(1)
+
+/*
+
+    Eat Rations
+    Quick meal — small morale boost.
+
+*/
+= do_eat_rations
+~ Morale = MIN(Morale + 3, 100)
+You heat up a packet of rations. It's not gourmet, but it fills the hole.
+-> pass_time(1)
+
+/*
+
+    Recreation
+    Flexible recreation handler. Cost and morale boost are parameters.
+
+*/
+= do_recreation(cost, morale_boost)
+~ Morale = MIN(Morale + morale_boost, 100)
+{ cost > 1:
+    You settle in for a movie. For a couple of hours, you're not a trucker — you're just an audience.
+- else:
+    You run through a quick workout routine. Your muscles thank you.
+}
+-> pass_time(cost)
+
+/*
+
     Sleep
+    Full sleep (2 AP) resets fatigue to 0.
+    Nap (1 AP) reduces fatigue by 25.
 
 */
 = sleep(amount)
-~ AwakeDuration = 0
 { amount > 1:
+    ~ Fatigue = 0
     You fall into your bunk and sleep like the dead.
-    -> pass_time(2)
 - else:
-    You grab a quick power nap in the captain's chair. It's better than nothing.
-    -> pass_time(1)
+    ~ Fatigue = MAX(Fatigue - 25, 0)
+    You grab a quick power nap in the captain's chair. It takes the edge off.
 }
+-> pass_time(amount)
 
 /*
 
     Pass Time
-    Reduce the available action point.
+    Deduct AP. If not sleeping, accumulate fatigue with gravity modifier.
 
 */
 = pass_time(amount)
 ~ AP -= amount
 { not came_from(-> sleep):
-    ~ AwakeDuration += amount
+    // Gravity-modified fatigue: Turbo is more fatiguing, Eco is less
+    ~ temp fatigue_gain = amount * 10
+    { FlightMode == Turbo:
+        ~ fatigue_gain = amount * 15
+    }
+    { FlightMode == Eco:
+        ~ fatigue_gain = amount * 8
+    }
+    ~ Fatigue = MIN(Fatigue + fatigue_gain, 100)
 }
 { AP > 0:
     -> ship_options
@@ -81,12 +236,30 @@ Flying to {LocationData(destination, Name)} for {duration} days…
 /*
 
     Next Day
-    Advance the clock and reset the available action points.
+    Advance the clock, degrade conditions, decay morale, reset AP.
 
 */
 = next_day(rollover)
 ~ ShipClock--
+~ TripDay++
 ~ AP = ActionPointsMax + rollover
+// Daily degradation
+~ ShipCondition = MAX(ShipCondition - 1, 0)
+~ EngineCondition = MAX(EngineCondition - 1, 0)
+// Morale decay: faster if ship is dirty
+{ ShipCondition < 50:
+    ~ Morale = MAX(Morale - 3, 0)
+- else:
+    ~ Morale = MAX(Morale - 1, 0)
+}
+// Low morale reduces effective AP
+{ Morale < 20:
+    ~ AP = MIN(AP, 4)
+- else:
+    { Morale < 40:
+        ~ AP = MIN(AP, 5)
+    }
+}
 { ShipClock == 0:
     -> arrive_in_port(ShipDestination)
 }
@@ -95,18 +268,18 @@ Flying to {LocationData(destination, Name)} for {duration} days…
 /*
 
     Can The Player Sleep?
-    Checks if it's been long enough since the player last slept to offer sleep actions again.
+    Returns true when fatigue is high enough to offer sleep options.
 
 */
 === function can_sleep()
-~ return AwakeDuration >= ActionPointsMax - 2
+~ return Fatigue >= 30
 
 /*
 
     Is The Player Overtired?
-    Returns true when the player has been awake longer than their action point maximum,
-    triggering a fatigue warning in ship_options.
+    Returns true when fatigue is dangerously high,
+    triggering warnings and future task failure chance.
 
 */
 === function is_overtired()
-~ return AwakeDuration > ActionPointsMax
+~ return Fatigue >= 70

--- a/space-truckers.ink
+++ b/space-truckers.ink
@@ -12,12 +12,25 @@ VAR PlayerBankBalance = 200
 VAR PayRate = 3
 
 LIST Manufacturers = Kepler, Olympus, Huygens
+LIST FlightModes = Eco, Bal, Turbo
 
 VAR ShipManufacturer = Kepler
 VAR ShipEngineTier = 1
 VAR ShipFuelCapacity = 300
 VAR ShipFuel = 225
 VAR ShipCargo = ()
+VAR FlightMode = Bal
+
+VAR Fatigue = 0           // 0–100 scale. Gravity-modified accumulation.
+VAR Morale = 80           // 0–100 scale. Decays daily, boosted by recreation.
+VAR ShipCondition = 100   // 0–100%. Degrades 1%/day. Affects morale.
+VAR EngineCondition = 100 // 0–100%. Degrades 1%/day. Affects fuel cost.
+
+VAR TripDay = 0           // Current day of trip (incremented in next_day)
+VAR TripDuration = 0      // Total trip length in days
+VAR FlipDone = false      // Has the ship flip been executed this trip?
+VAR PaperworkDone = 0     // Chunks completed
+VAR PaperworkTotal = 0    // Chunks required (calculated at departure)
 
 LIST EngineStats = FuelCap, EcoFuel, EcoSpeed, BalFuel, BalSpeed, TurboFuel, TurboSpeed
 

--- a/tests/unit/cargo.test.js
+++ b/tests/unit/cargo.test.js
@@ -251,6 +251,41 @@ describe("cargo_express_destination", () => {
   });
 });
 
+describe("count_paperwork_chunks", () => {
+  it("returns 1 (base chunk) for empty cargo", () => {
+    const result = story.EvaluateFunction("count_paperwork_chunks", [new InkList()]);
+    expect(result).toBe(1);
+  });
+
+  it("returns 1 (base chunk) for unflagged cargo only", () => {
+    const items = cargo(story, "AllCargo.003_Water", "AllCargo.101_Helium");
+    const result = story.EvaluateFunction("count_paperwork_chunks", [items]);
+    expect(result).toBe(1);
+  });
+
+  it("returns 2 for one hazardous item (base + 1 flagged)", () => {
+    const result = story.EvaluateFunction("count_paperwork_chunks", [L(story, "AllCargo.501_Methane")]);
+    expect(result).toBe(2);
+  });
+
+  it("returns 2 for one passenger item (base + 1 flagged)", () => {
+    const result = story.EvaluateFunction("count_paperwork_chunks", [L(story, "AllCargo.304_Colonists")]);
+    expect(result).toBe(2);
+  });
+
+  it("returns 2 for one express item (base + 1 flagged)", () => {
+    const result = story.EvaluateFunction("count_paperwork_chunks", [L(story, "AllCargo.001_Plums")]);
+    expect(result).toBe(2);
+  });
+
+  it("returns 3 for two flagged items among unflagged cargo", () => {
+    // 003_Water (plain) + 501_Methane (hazardous) + 304_Colonists (passengers)
+    const items = cargo(story, "AllCargo.003_Water", "AllCargo.501_Methane", "AllCargo.304_Colonists");
+    const result = story.EvaluateFunction("count_paperwork_chunks", [items]);
+    expect(result).toBe(3);
+  });
+});
+
 describe("can_turbo_to", () => {
   // Tier 1: TurboFuel=4.0, FuelCap=300, ship mass=5 (no cargo)
   // Cost formula: FLOOR(distance × mass × fuel_factor)

--- a/tests/unit/ship.test.js
+++ b/tests/unit/ship.test.js
@@ -1,11 +1,11 @@
 /**
- * Unit tests for extracted ship functions.
+ * Unit tests for ship functions.
  *
  *   can_sleep()
- *     → true when AwakeDuration >= ActionPointsMax - 2 (i.e., >= 4 with default max of 6)
+ *     → true when Fatigue >= 30
  *
  *   is_overtired()
- *     → true when AwakeDuration > ActionPointsMax (i.e., > 6 with default max of 6)
+ *     → true when Fatigue >= 70
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
@@ -15,49 +15,48 @@ let story;
 
 beforeEach(() => {
   story = createStory();
-  // ActionPointsMax defaults to 6
 });
 
 describe("can_sleep", () => {
-  it("returns false when AwakeDuration is 0 (just woke up)", () => {
-    story.variablesState["AwakeDuration"] = 0;
+  it("returns false when Fatigue is 0 (fully rested)", () => {
+    story.variablesState["Fatigue"] = 0;
     expect(story.EvaluateFunction("can_sleep", [])).toBe(false);
   });
 
-  it("returns false when AwakeDuration is 3 (below threshold)", () => {
-    story.variablesState["AwakeDuration"] = 3;
+  it("returns false when Fatigue is 20 (below threshold)", () => {
+    story.variablesState["Fatigue"] = 20;
     expect(story.EvaluateFunction("can_sleep", [])).toBe(false);
   });
 
-  it("returns true at threshold (AwakeDuration = ActionPointsMax - 2 = 4)", () => {
-    story.variablesState["AwakeDuration"] = 4;
+  it("returns true at threshold (Fatigue = 30)", () => {
+    story.variablesState["Fatigue"] = 30;
     expect(story.EvaluateFunction("can_sleep", [])).toBe(true);
   });
 
-  it("returns true when AwakeDuration exceeds threshold", () => {
-    story.variablesState["AwakeDuration"] = 8;
+  it("returns true when Fatigue exceeds threshold", () => {
+    story.variablesState["Fatigue"] = 80;
     expect(story.EvaluateFunction("can_sleep", [])).toBe(true);
   });
 });
 
 describe("is_overtired", () => {
-  it("returns false when AwakeDuration is 0", () => {
-    story.variablesState["AwakeDuration"] = 0;
+  it("returns false when Fatigue is 0", () => {
+    story.variablesState["Fatigue"] = 0;
     expect(story.EvaluateFunction("is_overtired", [])).toBe(false);
   });
 
-  it("returns false when AwakeDuration equals ActionPointsMax (6)", () => {
-    story.variablesState["AwakeDuration"] = 6;
+  it("returns false when Fatigue is 60 (below threshold)", () => {
+    story.variablesState["Fatigue"] = 60;
     expect(story.EvaluateFunction("is_overtired", [])).toBe(false);
   });
 
-  it("returns true when AwakeDuration exceeds ActionPointsMax (7)", () => {
-    story.variablesState["AwakeDuration"] = 7;
+  it("returns true at threshold (Fatigue = 70)", () => {
+    story.variablesState["Fatigue"] = 70;
     expect(story.EvaluateFunction("is_overtired", [])).toBe(true);
   });
 
   it("returns true when severely overtired", () => {
-    story.variablesState["AwakeDuration"] = 12;
+    story.variablesState["Fatigue"] = 100;
     expect(story.EvaluateFunction("is_overtired", [])).toBe(true);
   });
 });


### PR DESCRIPTION
## Changes

### Player Stats
- Added fatigue system (0–100 scale) with gravity-modified accumulation based on flight mode
- Added morale system (0–100 scale) with daily decay affected by ship cleanliness
- Added ship condition tracking (0–100%) with daily degradation
- Added engine condition tracking (0–100%) with daily degradation

### Transit Tasks
- Replaced placeholder transit tasks with priority-ordered action system:
  - **P1**: Ship flip (required at midpoint)
  - **P2**: Engine maintenance, sleep (when urgent)
  - **P3**: Paperwork, navigation checks, ship maintenance
  - **P4**: Recreation, eating, napping
- Implemented paperwork chunk system: 1 base + 1 per special-flagged cargo item
- Added daily state progression: ship degradation, morale decay, AP cap based on morale
- Flight mode now affects fatigue accumulation (Turbo 1.5x, Eco 0.8x)

### Tracking Variables
- `TripDay`, `TripDuration`, `FlipDone`, `FlightMode`
- `PaperworkDone`, `PaperworkTotal`
- Replaced `AwakeDuration` with `Fatigue` for stat-based system

### Tests
- Added 6 new unit tests for `count_paperwork_chunks()` function
- Updated 10 ship stat tests to use `Fatigue` thresholds (30 for sleep, 70 for overtired)