### PR TITLE
Wire up economic penalties for transit tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ Before opening a PR, verify it contains only the intended commits: `git log --on
 
 New constants added to `simulator.html` must include a citation comment pointing to the Ink source.
 
+## Documentation
+
+Before opening a PR, review `docs/developer-guide.md` and `docs/player-guide.md` to check if changes in the PR require documentation updates. Update them as part of the PR.
+
 ## Testing
 
 Always run `npm test` before opening a PR. CI runs `npm run lint` then `npm test` — both must pass.

--- a/cargo.ink
+++ b/cargo.ink
@@ -1595,3 +1595,17 @@ LIST AllCargo =
     }
 }
 ~ return 0
+
+/*
+
+    Get Paperwork Penalty Percentage
+    Returns the delivery pay reduction for incomplete paperwork.
+    Each missing chunk costs 10% of pay, capped at 50%.
+
+*/
+=== function get_paperwork_penalty_pct(done, total)
+~ temp missing = total - done
+{ missing <= 0:
+    ~ return 0
+}
+~ return MIN(missing * 10, 50)  // 10% per missing chunk, capped at 50%

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -186,6 +186,69 @@ The goal is that no flag is a pure upside. Each one closes off an option while o
 
 ---
 
+## Economic Penalties
+
+The transit system applies economic penalties when the player neglects tasks. The design principle is "failure = complication, not disaster" — a single missed task is noticeable but not devastating, while neglecting everything can make a trip unprofitable.
+
+### Penalty Currencies
+
+Penalties come in two forms:
+
+- **Fuel penalties** accumulate mid-trip in `TripFuelPenalty` and are settled on arrival by deducting from `ShipFuel`. If fuel goes to zero, a towing narrative fires with a large money penalty.
+- **Money penalties** (paperwork fines) reduce delivery pay at port.
+
+### Engine Degradation
+
+Engine condition degrades 1% per day during transit. Degraded engines burn more fuel, applied at departure:
+
+```
+penalty_pct = (100 - EngineCondition) / 2
+extra_fuel = FLOOR(base_cost × penalty_pct / 100)
+```
+
+At 80% condition, fuel costs are 10% higher. At 50%, they're 25% higher. This is calculated in `get_engine_fuel_penalty()` (locations.ink) and added to displayed fuel costs in `flight_options` (port.ink). The base `get_trip_fuel_cost` function is unchanged — it's also used for cargo filtering at port, where degradation shouldn't apply.
+
+### Mid-Trip Fuel Penalties
+
+These accumulate in `TripFuelPenalty` during transit and are settled in `settle_trip_penalties` on arrival:
+
+| Penalty | Trigger | Amount |
+|---|---|---|
+| Flip delay | Each day past midpoint without flipping | +5% of trip fuel cost per day |
+| Sloppy flip | Executing flip while overtired | +10% of trip fuel cost (one-time) |
+| Missed nav check | Not doing a nav check when offered | +10% of trip fuel cost per missed check |
+
+Nav checks appear every 3 days (`TripDay mod 3 == 0, TripDay > 0`). Expected check count: `(TripDuration - 1) / 3`.
+
+### Paperwork Fines
+
+Incomplete paperwork reduces delivery pay. The penalty is calculated by `get_paperwork_penalty_pct()` (cargo.ink):
+
+```
+penalty = MIN(missing_chunks × 10, 50)%
+```
+
+Each missing chunk costs 10% of delivery pay, capped at 50%. This is applied per-item during `deliver_cargo` (port.ink).
+
+### Towing Scenario
+
+If `TripFuelPenalty` exceeds remaining `ShipFuel` on arrival, fuel is set to 0 and the player pays a tow fee of 200% of the trip's base fuel cost. This can push `PlayerBankBalance` negative.
+
+### Ink Integer Math Pitfall
+
+Ink evaluates `a * b / c` as `a * (b / c)`, not `(a * b) / c`. With integer math, this causes silent truncation to zero when `b < c`. Always store the multiplication result in a temp variable before dividing:
+
+```ink
+// WRONG — penalty_pct / 100 truncates to 0 in integer math
+~ return FLOOR(base_cost * penalty_pct / 100)
+
+// CORRECT — multiply first, then divide
+~ temp product = base_cost * penalty_pct
+~ return FLOOR(product / 100)
+```
+
+---
+
 ## Adding New Content
 
 ### New Cargo Entry

--- a/docs/player-guide.md
+++ b/docs/player-guide.md
@@ -81,6 +81,41 @@ This might seem backwards, but it makes sense: the outer planets are rich in raw
 
 ---
 
+## Life in Transit
+
+Flying between ports isn't just sitting around. You've got a ship to maintain and paperwork to file. Each day in transit, you'll spend **action points (AP)** on various tasks. You start each day with 6 AP, and everything costs 1 or 2 AP.
+
+### The Ship Flip
+
+At the midpoint of every trip, your ship needs to rotate 180 degrees to begin decelerating. This is a required maneuver — if you delay it, course corrections burn extra fuel. Do it promptly, and do it rested. Executing the flip while exhausted results in a sloppy maneuver that wastes fuel.
+
+### Navigation Checks
+
+Every few days, a navigation check will appear in your task list. These are quick (1 AP) and keep your course efficient. Skip them and you'll burn extra fuel compensating on arrival.
+
+### Paperwork
+
+Every trip requires customs documentation — one base chunk of flight log paperwork, plus extra forms for any special cargo (Express, Hazardous, Passengers). You can file paperwork at any point during the trip, but any missing chunks when you dock result in customs fines that reduce your delivery pay.
+
+### Engine Condition
+
+Your engine degrades 1% per day during transit. A degraded engine burns more fuel — at 80% condition, fuel costs are 10% higher. You can spend AP on engine maintenance during transit to keep it in shape, and ship condition resets when you reach port.
+
+### Ship Condition
+
+The general state of your ship (cleanliness, air filters, tidiness) also degrades daily. A dirty ship affects your morale, which can reduce your daily AP. Spending time cleaning keeps things livable.
+
+### Fatigue and Morale
+
+You have two personal stats to manage:
+
+- **Fatigue** builds up as you work. Sleep (2 AP) resets it fully; naps (1 AP) take the edge off. If you push too hard, you'll start making mistakes — like that sloppy ship flip.
+- **Morale** decays slowly each day, faster if your ship is a mess. Recreation activities (cooking a meal, watching a movie, exercising) restore it. If morale drops too low, you'll lose AP each day.
+
+The early game is a balancing act: there's a lot of work to do and not enough hours. As you upgrade your ship, automation handles more of the busywork, leaving more time for you.
+
+---
+
 ## Engine Upgrades
 
 The biggest improvement you can make to your ship is upgrading the engine. Each generation of engine is more efficient and faster in every mode.
@@ -105,10 +140,16 @@ The late-game feeling is qualitatively different from the early game. Your first
 
 **Start local.** Earth↔Moon and Earth↔Mars runs might feel small, but they're reliable. Learn the economics before venturing further out.
 
-**Watch your fuel before you commit.** The departure screen shows fuel costs for every available mode. Check them before you choose. Running out of fuel mid-transit isn't an option — you need enough to complete the trip.
+**Watch your fuel before you commit.** The departure screen shows fuel costs for every available mode. Check them before you choose. If your engine is degraded, those costs go up.
 
 **Light loads unlock faster modes.** If you're eyeing Express cargo but your tank won't cover Turbo with a full hold, consider taking less. A lighter load at a higher mode can pay more than a heavy load at Economy.
 
 **Hazardous pays well, but think it through.** Accepting Hazardous cargo means your whole hold is committed to that one contract. Make sure the payout is worth giving up the rest of your capacity.
 
 **Cheap outer-system fuel is worth the trip.** Once your engine can reach Ceres or Ganymede reliably, refuelling there instead of at Earth saves money on every subsequent run.
+
+**Do the flip on time.** Every day you delay the midpoint flip costs extra fuel. And don't do it exhausted — get some sleep first.
+
+**Don't skip paperwork.** The customs fines for missing documentation add up. Special cargo generates extra paperwork, so factor that into your planning when loading flagged cargo.
+
+**Sleep is productive.** It's tempting to spend every AP on tasks, but working while exhausted leads to mistakes. A well-rested pilot wastes less fuel and gets more done.

--- a/locations.ink
+++ b/locations.ink
@@ -101,6 +101,30 @@ CONST FuelCostOuter = 0.8
     Outer system (Ganymede, Titan):   €0.8
 
 */
+/*
+
+    Get Engine Fuel Penalty
+    Returns additional fuel cost from engine degradation.
+    Formula: +5% fuel cost per 10% degradation below 100%.
+
+*/
+=== function get_engine_fuel_penalty(base_cost)
+~ temp degradation = 100 - EngineCondition
+~ temp penalty_pct = degradation / 2  // +5% fuel cost per 10% degradation
+~ temp extra_fuel = base_cost * penalty_pct
+~ return FLOOR(extra_fuel / 100)
+
+/*
+
+    Get Fuel Price
+
+    Returns actual euro price as a float (1.2, 1.0, or 0.8).
+
+    Inner system (Earth, Luna, Mars): €1.2
+    Belt (Ceres):                     €1.0
+    Outer system (Ganymede, Titan):   €0.8
+
+*/
 === function get_fuel_price(location)
 { location:
 - Earth:

--- a/port.ink
+++ b/port.ink
@@ -7,17 +7,11 @@ VAR PortCargo = ()
 */
 === arrive_in_port(port)
 ~ here = port
-~ PortCargo = get_available_cargo(port, 5)
 ~ ShipCondition = 100
+-> settle_trip_penalties ->
+~ PortCargo = get_available_cargo(port, 5)
 
 Welcome to {LocationData(port, Name)}!
-
-// Paperwork settlement
-{ PaperworkDone < PaperworkTotal:
-    ~ temp missing = PaperworkTotal - PaperworkDone
-    You didn't complete all your paperwork. The port authority hits you with a customs fine for {missing} missing document{missing > 1:s}.
-    // TODO: calculate and apply actual fine amount
-}
 
 - (port_opts)
 + [Load cargo]
@@ -108,12 +102,46 @@ current mass = {total_mass(ShipCargo)}t
 
 /*
 
+    Settle Trip Penalties
+    Called on arrival. Calculates missed nav check fuel penalties,
+    applies accumulated fuel penalties, and handles the towing scenario.
+    Paperwork penalties are applied separately during delivery.
+
+*/
+= settle_trip_penalties
+// Nav check penalty: 10% of trip fuel per missed check
+// Checks appear every 3 days (TripDay mod 3 == 0, TripDay > 0)
+~ temp expected_checks = (TripDuration - 1) / 3
+~ temp missed_checks = expected_checks - NavChecksCompleted
+{ missed_checks > 0:
+    ~ TripFuelPenalty = TripFuelPenalty + missed_checks * (TripFuelCost / 10)  // +10% trip fuel per missed check
+}
+// Apply accumulated fuel penalty
+{ TripFuelPenalty > 0:
+    ~ ShipFuel = ShipFuel - TripFuelPenalty
+    { ShipFuel > 0:
+        Course corrections and compensations burned {TripFuelPenalty} extra fuel this trip.
+    - else:
+        ~ ShipFuel = 0
+        You ran out of fuel before reaching port. After drifting for days, a salvage tug picks up your distress beacon and tows you in. The tow fee is steep.
+        ~ temp tow_fee = TripFuelCost * 2  // tow fee = 200% of trip fuel cost
+        ~ PlayerBankBalance = PlayerBankBalance - tow_fee
+        Tow fee: {tow_fee} €. Your balance is now {PlayerBankBalance} €.
+    }
+}
+->->
+
+/*
+
     Deliver Cargo
+    Delivers all cargo destined for the current port.
+    Incomplete paperwork reduces pay by 10% per missing chunk (capped at 50%).
 
 */
 = deliver_cargo
 ~ temp _items = ShipCargo
 ~ temp delivery_count = 0
+~ temp paperwork_penalty_pct = get_paperwork_penalty_pct(PaperworkDone, PaperworkTotal)
 - (top)
 ~ temp cargo = pop(_items)
 { cargo:
@@ -123,13 +151,23 @@ current mass = {total_mass(ShipCargo)}t
         ~ ShipCargo -= cargo
         ~ temp dist = get_distance(CargoData(cargo, From), here)
         ~ temp pay = get_cargo_pay(cargo, dist)
+        ~ temp penalty_amount = pay * paperwork_penalty_pct
+        ~ temp penalty = penalty_amount / 100
+        ~ pay = pay - penalty
         ~ PlayerBankBalance += pay
         ~ temp fromName = LocationData(CargoData(cargo, From), Name)
-        Delivered {CargoData(cargo, Title)} from {fromName} for {pay} €.
+        { penalty > 0:
+            Delivered {CargoData(cargo, Title)} from {fromName} for {pay} € ({penalty} € customs fine).
+        - else:
+            Delivered {CargoData(cargo, Title)} from {fromName} for {pay} €.
+        }
     }
     -> top
 }
 { delivery_count > 0:
+    { paperwork_penalty_pct > 0:
+        Incomplete paperwork cost you {paperwork_penalty_pct}% of your delivery pay.
+    }
     All cargo for {LocationData(here, Name)} delivered! Your bank account balance is {PlayerBankBalance} €.
 - else:
     You have no cargo to deliver to {LocationData(here, Name)}.
@@ -236,6 +274,10 @@ The current unit cost of fuel is {price} €. Your fuel gauge reads {ShipFuel}/{
 ~ temp slow_cost   = get_trip_fuel_cost(here, to, eco_fuel)
 ~ temp norm_cost   = get_trip_fuel_cost(here, to, bal_fuel)
 ~ temp fast_cost   = get_trip_fuel_cost(here, to, turbo_fuel)
+// Apply engine degradation fuel penalty to displayed costs
+~ slow_cost = slow_cost + get_engine_fuel_penalty(slow_cost)
+~ norm_cost = norm_cost + get_engine_fuel_penalty(norm_cost)
+~ fast_cost = fast_cost + get_engine_fuel_penalty(fast_cost)
 ~ temp slow_time   = get_trip_duration(here, to, eco_speed)
 ~ temp norm_time   = get_trip_duration(here, to, bal_speed)
 ~ temp fast_time   = get_trip_duration(here, to, turbo_speed)
@@ -243,6 +285,9 @@ The current unit cost of fuel is {price} €. Your fuel gauge reads {ShipFuel}/{
 ~ temp has_express    = cargo_has_express(ShipCargo)
 ~ temp blocks_turbo   = cargo_blocks_turbo(ShipCargo)
 You have {ShipFuel} fuel, and a total mass of {total_mass(ShipCargo)}t.
+{EngineCondition < 100:
+    Engine condition: {EngineCondition}% — fuel costs increased.
+}
 + {can_use_flight_mode(has_express, ShipFuel, slow_cost)}
     [Economy Mode ({slow_cost} fuel, {slow_time} days)]
     -> transit(to, slow_cost, slow_time, Eco)

--- a/ship.ink
+++ b/ship.ink
@@ -1,8 +1,5 @@
 // TODO: ship modules degrade and need maintenance
 // TODO: Fatigue affects task success (chance to fail tasks when overtired)
-// TODO: ship flip fuel penalty for delay (each day past midpoint = +5% trip fuel)
-// TODO: sloppy flip (overtired) fuel penalty
-// TODO: navigation check skip penalty (extra fuel on arrival)
 // TODO: contextual ship maintenance variety (drain lines, laundry, secure items, etc.)
 // TODO: passenger events when carrying passenger cargo
 // TODO: random events (micrometeorite, power surge, cargo shift, distress signal, etc.)
@@ -28,6 +25,9 @@ VAR ActionPointsMax = 6
 ~ FlightMode = mode
 ~ PaperworkTotal = count_paperwork_chunks(ShipCargo)
 ~ PaperworkDone = 0
+~ TripFuelCost = fuel_cost
+~ TripFuelPenalty = 0
+~ NavChecksCompleted = 0
 Flying to {LocationData(destination, Name)} for {duration} days…
 -> ship_options
 
@@ -108,8 +108,8 @@ Flying to {LocationData(destination, Name)} for {duration} days…
 = do_flip
 ~ FlipDone = true
 { is_overtired():
-    Your hands tremble on the controls as you initiate the flip sequence. The ship groans through the rotation — not your cleanest work.
-    // TODO: track fuel penalty for sloppy flip
+    ~ TripFuelPenalty = TripFuelPenalty + TripFuelCost / 10  // +10% sloppy flip penalty
+    Your hands tremble on the controls as you initiate the flip sequence. The ship groans through the rotation — not your cleanest work. The sloppy maneuver will cost you extra fuel.
 - else:
     You initiate the flip sequence. The stars wheel past the viewport as the ship rotates 180 degrees. Engines now pointing forward for deceleration. Textbook.
 }
@@ -138,8 +138,8 @@ Flying to {LocationData(destination, Name)} for {duration} days…
 
 */
 = do_nav_check
+~ NavChecksCompleted++
 You review the flight trajectory and make minor course corrections. Everything's on track.
-// TODO: track nav checks completed; missed checks add fuel penalty at arrival
 -> pass_time(1)
 
 /*
@@ -243,6 +243,10 @@ You heat up a packet of rations. It's not gourmet, but it fills the hole.
 ~ ShipClock--
 ~ TripDay++
 ~ AP = ActionPointsMax + rollover
+// Flip delay penalty: +5% trip fuel for each day past midpoint without flipping
+{ not FlipDone and TripDay > TripDuration / 2:
+    ~ TripFuelPenalty = TripFuelPenalty + TripFuelCost / 20  // +5% trip fuel per day delayed
+}
 // Daily degradation
 ~ ShipCondition = MAX(ShipCondition - 1, 0)
 ~ EngineCondition = MAX(EngineCondition - 1, 0)

--- a/space-truckers.ink
+++ b/space-truckers.ink
@@ -31,6 +31,9 @@ VAR TripDuration = 0      // Total trip length in days
 VAR FlipDone = false      // Has the ship flip been executed this trip?
 VAR PaperworkDone = 0     // Chunks completed
 VAR PaperworkTotal = 0    // Chunks required (calculated at departure)
+VAR TripFuelCost = 0      // Base fuel cost of current trip (for % penalty calcs)
+VAR TripFuelPenalty = 0   // Accumulated fuel penalty during transit
+VAR NavChecksCompleted = 0 // Nav checks completed this trip
 
 LIST EngineStats = FuelCap, EcoFuel, EcoSpeed, BalFuel, BalSpeed, TurboFuel, TurboSpeed
 

--- a/tests/unit/cargo.test.js
+++ b/tests/unit/cargo.test.js
@@ -286,6 +286,43 @@ describe("count_paperwork_chunks", () => {
   });
 });
 
+describe("get_paperwork_penalty_pct", () => {
+  // Formula: MIN(missing × 10, 50) where missing = total - done
+  // 10% per missing chunk, capped at 50%
+
+  function penaltyPct(done, total) {
+    return story.EvaluateFunction("get_paperwork_penalty_pct", [done, total]);
+  }
+
+  it("returns 0 when all paperwork is done", () => {
+    expect(penaltyPct(3, 3)).toBe(0);
+  });
+
+  it("returns 0 when done exceeds total", () => {
+    expect(penaltyPct(5, 3)).toBe(0);
+  });
+
+  it("returns 10 for 1 missing chunk", () => {
+    expect(penaltyPct(2, 3)).toBe(10);
+  });
+
+  it("returns 20 for 2 missing chunks", () => {
+    expect(penaltyPct(1, 3)).toBe(20);
+  });
+
+  it("returns 30 for 3 missing chunks", () => {
+    expect(penaltyPct(0, 3)).toBe(30);
+  });
+
+  it("caps at 50 for 5+ missing chunks", () => {
+    expect(penaltyPct(0, 6)).toBe(50);
+  });
+
+  it("returns 0 when total is 0 (no paperwork)", () => {
+    expect(penaltyPct(0, 0)).toBe(0);
+  });
+});
+
 describe("can_turbo_to", () => {
   // Tier 1: TurboFuel=4.0, FuelCap=300, ship mass=5 (no cargo)
   // Cost formula: FLOOR(distance × mass × fuel_factor)

--- a/tests/unit/locations.test.js
+++ b/tests/unit/locations.test.js
@@ -158,6 +158,46 @@ describe("get_trip_fuel_cost", () => {
   });
 });
 
+describe("get_engine_fuel_penalty", () => {
+  // Formula: FLOOR(base_cost × (100 - EngineCondition) / 2 / 100)
+  // +5% fuel cost per 10% degradation below 100%
+  // Uses fresh story per test to avoid shared state issues with EngineCondition.
+
+  function penalty(baseCost, condition) {
+    const s = createStory();
+    s.variablesState["ShipCargo"] = new InkList();
+    s.variablesState["EngineCondition"] = condition;
+    return s.EvaluateFunction("get_engine_fuel_penalty", [baseCost]);
+  }
+
+  it("returns 0 at 100% condition", () => {
+    expect(penalty(280, 100)).toBe(0);
+  });
+
+  it("returns 5% at 90% condition: FLOOR(280 × 5 / 100) = 14", () => {
+    expect(penalty(280, 90)).toBe(14);
+  });
+
+  it("returns 10% at 80% condition: FLOOR(280 × 10 / 100) = 28", () => {
+    expect(penalty(280, 80)).toBe(28);
+  });
+
+  it("returns 25% at 50% condition: FLOOR(280 × 25 / 100) = 70", () => {
+    expect(penalty(280, 50)).toBe(70);
+  });
+
+  it("returns 0 at 100% condition even with large base cost", () => {
+    expect(penalty(10000, 100)).toBe(0);
+  });
+
+  it("floors fractional results", () => {
+    // At 90%: FLOOR(100 × 5 / 100) = FLOOR(5) = 5
+    expect(penalty(100, 90)).toBe(5);
+    // At 90%: FLOOR(50 × 5 / 100) = FLOOR(2.5) = 2
+    expect(penalty(50, 90)).toBe(2);
+  });
+});
+
 describe("get_fuel_price", () => {
   it("Earth is inner system: 1.2", () => {
     expect(story.EvaluateFunction("get_fuel_price", [loc("Earth")])).toBeCloseTo(1.2);


### PR DESCRIPTION
## Summary

- **Engine degradation** now increases displayed fuel costs at departure (+5% per 10% degradation below 100%)
- **Mid-trip fuel penalties** accumulate in `TripFuelPenalty` and are settled on arrival: flip delay (+5%/day past midpoint), sloppy flip (+10%), missed nav checks (+10% each)
- **Paperwork fines** reduce delivery pay at port (10% per missing chunk, capped at 50%)
- **Towing scenario** fires if accumulated penalties exhaust remaining fuel on arrival (200% tow fee)
- New `get_paperwork_penalty_pct()` and `get_engine_fuel_penalty()` functions are independently testable
- Documents the Ink integer math pitfall (`a * b / c` evaluates as `a * (b/c)`) with correct/wrong examples

## Test plan

- [x] \`npm run lint\` — Ink compiles clean
- [x] \`npm test\` — 407/407 tests pass, including new suites for \`get_engine_fuel_penalty\` and \`get_paperwork_penalty_pct\`
- [ ] Manual: set \`EngineCondition=80\`, verify fuel costs are ~10% higher in flight options
- [ ] Manual: skip the flip past midpoint, verify fuel penalty message on arrival
- [ ] Manual: skip all nav checks, verify fuel penalty on arrival
- [ ] Manual: don't file paperwork, verify reduced pay with customs fine message on delivery
- [ ] Manual: extreme neglect on a long trip — verify penalties stack but don't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)