### PR TITLE
Add passenger random events (#4)

### DIFF
--- a/cargo.ink
+++ b/cargo.ink
@@ -1519,6 +1519,21 @@ LIST AllCargo =
 
 /*
 
+    Returns true if any cargo in the hold has the Passengers flag.
+
+*/
+=== function has_passenger_cargo(items)
+~ temp item = pop(items)
+{ item:
+    { CargoData(item, Passengers):
+        ~ return true
+    }
+    ~ return has_passenger_cargo(items)
+}
+~ return false
+
+/*
+
     Gets a randomized selection of cargo from the specified port.
     Express cargo is filtered out if the destination is unreachable in Turbo
     at the player's current engine tier.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -333,17 +333,24 @@ Random events are P0 interruptions that fire during transit, bypassing the task 
 **Triggering:** Each time `ship_options` is entered, an escalating probability check fires. `EventChance` starts at 0 and increases by 3 per check. When an event fires, `EventChance` resets to 0 and `EventCooldownDay` is set to the current `TripDay` to prevent a second event the same day.
 
 **Event selection:** When triggered, `random_event` picks randomly from eligible events. Some events have eligibility conditions:
-- **Cargo shift** — only eligible when the player has cargo
-- **Shortcut** — only eligible when `ShipClock > 1`
+- **Cargo shift** — only eligible when the player has cargo (static check at trip start)
+- **Shortcut** — only eligible when `ShipClock > 1` (dynamic check each roll)
+- **Passenger events** — only eligible when the player has passenger cargo (static check at trip start)
+
+**Passenger event eligibility:** The `PassengerEvents` VAR holds the subset of events that require passengers. In `transit()`, `Events -= PassengerEvents` removes all passenger events in one operation when no passenger cargo is aboard. To add a new passenger event, add it to both the `Events` LIST and the `PassengerEvents` VAR (they are adjacent in `events.ink`).
+
+**`has_medical_module()` stub:** Currently always returns `false`. When the module system is implemented (roadmap item #5), update this to check for an installed medical module. Used by the medical emergency event to improve patient outcomes.
 
 **Cargo damage:** `CargoDamagePct` accumulates cargo damage during transit (micrometeorite cargo hit, cargo shift with fatigue failure). It reduces delivery pay at port alongside paperwork penalties. Total combined penalty is capped at 75%. It only increases from event outcomes — normal transit never touches it.
 
 **`damage_random_system(amount)` stub:** Currently always damages `EngineCondition`. When modules are implemented (roadmap item #5), update this function to randomly choose from installed modules + engine.
 
 **Adding a new event:**
-1. Write an `event_*` knot in `events.ink`
-2. Add a branch to the `random_event` eligibility/selection block
-3. If the event has an eligibility condition, add it to `eligible_count` and the dispatch guard
+1. Add an entry to the `Events` LIST in `events.ink`
+2. If the event requires passenger cargo, also add it to the `PassengerEvents` VAR
+3. Write an `event_*` knot in `events.ink`
+4. Add a dispatch line in `random_event`: `{ chosen == Name: -> event_name }`
+5. If the event has a dynamic eligibility condition, add a removal line in `random_event`
 
 ---
 

--- a/docs/player-guide.md
+++ b/docs/player-guide.md
@@ -124,6 +124,8 @@ Space is unpredictable. On longer trips, unexpected things happen — a micromet
 
 Most events require immediate action (patching the hull, securing cargo), but some offer a choice. A distress signal from a nearby ship gives you options: stop and spend half your day helping them for a generous reward, pass over some supplies for a smaller reward, or radio for help and keep flying. A navigation shortcut might save you a day — or cost you one.
 
+When you're carrying passengers, you'll encounter additional events — birthdays to celebrate, complaints to handle, conversations to have, and the occasional medical emergency. Passengers make trips more interesting (and more stressful). That pay bonus exists for a reason.
+
 Being exhausted makes emergencies worse. A fatigued repair takes longer and may cause additional damage. Rest before you need it, not after something goes wrong.
 
 ---

--- a/events.ink
+++ b/events.ink
@@ -23,7 +23,11 @@
 // Event registry — tracks which events are still available this trip.
 // Events are set active at trip start and deactivated after firing,
 // preventing repeats. Add new events here and in the dispatch block below.
-LIST Events = (Micrometeorite), (PowerSurge), (DistressSignal), (CargoShift), (Shortcut)
+LIST Events = (Micrometeorite), (PowerSurge), (DistressSignal), (CargoShift), (Shortcut), (PassengerBirthday), (PassengerComplaint), (PassengerConversation), (MedicalEmergency)
+
+// Passenger event subset — removed from Events at trip start when no
+// passenger cargo is aboard. Keep in sync with the Events list above.
+VAR PassengerEvents = (PassengerBirthday, PassengerComplaint, PassengerConversation, MedicalEmergency)
 
 /*
 
@@ -54,6 +58,10 @@ LIST Events = (Micrometeorite), (PowerSurge), (DistressSignal), (CargoShift), (S
 { chosen == DistressSignal: -> event_distress_signal }
 { chosen == CargoShift: -> event_cargo_shift }
 { chosen == Shortcut: -> event_shortcut }
+{ chosen == PassengerBirthday: -> event_passenger_birthday }
+{ chosen == PassengerComplaint: -> event_passenger_complaint }
+{ chosen == PassengerConversation: -> event_passenger_conversation }
+{ chosen == MedicalEmergency: -> event_medical_emergency }
 // Fallback (shouldn't reach here)
 -> event_micrometeorite
 
@@ -67,6 +75,16 @@ LIST Events = (Micrometeorite), (PowerSurge), (DistressSignal), (CargoShift), (S
 */
 === function damage_random_system(amount)
 ~ EngineCondition = MAX(EngineCondition - amount, 0)
+
+/*
+
+    Medical Module Check
+    Stub: always returns false. When the module system is implemented
+    (roadmap item #5), update this to check for an installed medical module.
+
+*/
+=== function has_medical_module()
+~ return false
 
 /*
 
@@ -238,3 +256,140 @@ Your nav computer flags an alternate route — a gravitational slingshot corrido
     Turns out there's a reason nobody comes this way. The debris is denser than the charts suggested and you spend hours carefully threading through it. You've actually lost time.
 }
 -> transit.ship_options
+
+/*
+
+    Passenger Birthday
+    A passenger's birthday. Opportunity to celebrate.
+    Only fires when carrying passenger cargo.
+
+*/
+=== event_passenger_birthday
+One of your passengers flags you down in the corridor. Turns out it's their birthday — they're sheepish about mentioning it, but you can tell they'd appreciate some acknowledgment.
+
++ [Throw a small celebration — break out some rations and make it festive]
+    -> birthday_celebrate
++ [Wish them a happy birthday and get back to work]
+    ~ Morale = MIN(Morale + 5, 100)
+    You wish them well with a genuine smile. They seem touched that you remembered. Small gestures count for something out here.
+    -> transit.ship_options
+
+= birthday_celebrate
+You clear a table in the common area, dig out something that passes for cake mix, and round up the other passengers.
+{ fatigue_check():
+    You're running on fumes and it shows. The "celebration" is half-hearted — you burn the cake and can barely keep your eyes open through the singing. It's the thought that counts, but only just.
+    ~ Morale = MIN(Morale + 5, 100)
+- else:
+    It's nothing fancy, but the passengers are laughing and trading stories, and for a little while the ship feels less like a cargo hauler and more like somewhere people actually want to be.
+    ~ Morale = MIN(Morale + 10, 100)
+}
+-> transit.pass_time(1)
+
+/*
+
+    Passenger Complaint
+    A passenger is unhappy about conditions aboard the ship.
+    Only fires when carrying passenger cargo.
+
+*/
+=== event_passenger_complaint
+A passenger corners you outside the cockpit. The air recycler is making a noise that's keeping them up, the food is awful, and the heating in their berth is inconsistent. They want something done about it.
+
++ [See what you can do to fix their complaints]
+    -> complaint_accommodate
++ [Apologise but explain this is a cargo ship, not a cruise liner]
+    ~ Morale = MIN(MAX(Morale - 5, 0), 100)
+    You're sympathetic but honest — this is a working freighter, not a passenger vessel. They're not happy, but they accept it. The mood aboard drops a little.
+    -> transit.ship_options
+
+= complaint_accommodate
+You head down to check the recycler and tweak the heating.
+{ fatigue_check():
+    You try, but you're too tired to focus. You fiddle with the recycler and adjust the heating, but honestly you're not sure you've fixed anything. The passenger thanks you, though they don't sound convinced.
+- else:
+    ~ Morale = MIN(Morale + 5, 100)
+    The recycler had a loose panel — easy fix once you found it. You adjust the heating and throw in an extra blanket for good measure. The passenger seems genuinely grateful.
+}
+-> transit.pass_time(1)
+
+/*
+
+    Passenger Conversation
+    A passenger strikes up a conversation during downtime.
+    Only fires when carrying passenger cargo.
+    No fatigue check — this is a relaxing interaction.
+
+*/
+=== event_passenger_conversation
+You're running through a systems check when one of your passengers drifts into the cockpit. They're not complaining — they're just curious. They ask about the ship, the route, what it's like out here.
+
++ [Chat with them for a while]
+    ~ Morale = MIN(Morale + 5, 100)
+    ~ Fatigue = MAX(Fatigue - 5, 0)
+    You lean back and talk. They're good company — asking questions, listening to the answers, sharing their own stories. By the time they head back to their berth, you feel lighter than you have in days.
+    -> transit.pass_time(1)
++ [Politely excuse yourself — you've got work to do]
+    You explain you're in the middle of something and they nod, heading back without complaint. Back to work.
+    -> transit.ship_options
+
+/*
+
+    Medical Emergency
+    A passenger collapses with a medical emergency. The player must choose
+    between calling a medical shuttle (against the passenger's wishes) or
+    letting them stay aboard and gambling on the outcome.
+    Only fires when carrying passenger cargo.
+
+    // TODO: This event is a good candidate for a "delayed event outcome"
+    // system — resolve the passenger's fate a day or two later instead of
+    // immediately, to build tension. If another event would also benefit
+    // from delayed resolution, build the system then.
+
+*/
+=== event_medical_emergency
+A shout from the passenger berths snaps you out of your routine. One of your passengers has collapsed — they're conscious but in bad shape. You radio for emergency medical services and get a response: a fast medical shuttle can intercept your trajectory within hours.
+
+But when you tell the passenger, they grab your arm. Their family is aboard — spouse, kids. The shuttle only has room for the patient. "Please," they say. "Don't send me away from them."
+
+You look at the shuttle ETA on your console, then at the family huddled in the doorway. This feels like a bad idea. What if they get worse?
+
++ [Call the shuttle — their health comes first]
+    -> medical_call_shuttle
++ [Let them stay — respect their wishes and do what you can]
+    -> medical_stay_aboard
+
+= medical_call_shuttle
+You make the call. The passenger argues, then pleads, but you hold firm. When the shuttle docks, the medics transfer them quickly and professionally. The family watches from the airlock window as the shuttle pulls away.
+~ Morale = MIN(MAX(Morale - 10, 0), 100)
+~ ShipClock = ShipClock + 1
+The ship is quiet afterward. You did the right thing — you know that. But the kids won't look at you, and the silence is heavier than it should be.
+-> transit.pass_time(2)
+
+= medical_stay_aboard
+You tell the shuttle to stand by and turn back to the passenger. "Alright. You're staying. But you do exactly what I tell you."
+~ Morale = MIN(Morale + 5, 100)
+The family crowds in, grateful and terrified in equal measure. You dig out the first aid kit and do everything you can.
+-> medical_stay_outcome
+
+= medical_stay_outcome
+~ temp outcome_roll = RANDOM(1, 100)
+~ temp improve_chance = 50
+~ temp worsen_chance = 90
+{ has_medical_module():
+    ~ improve_chance = 75
+    ~ worsen_chance = 100  // no death possible with medical module
+}
+{
+- outcome_roll <= improve_chance:
+    Over the next few hours, colour returns to their face. Their breathing steadies. By evening they're sitting up, sipping water, and arguing with their spouse about whether they should have taken the shuttle. You take that as a good sign.
+- outcome_roll <= worsen_chance:
+    ~ Morale = MIN(MAX(Morale - 10, 0), 100)
+    They don't improve. If anything, they get worse — fever spikes, breathing goes shallow. You do what you can, but you're a pilot, not a doctor. They're stable enough to make it to port, but it's going to be a rough ride. You can't shake the feeling you made the wrong call.
+- else:
+    // 10% chance without medical module — the worst outcome
+    ~ Morale = MIN(MAX(Morale - 20, 0), 100)
+    You do everything right. You follow every step in the emergency manual. It's not enough.
+    They pass quietly in the small hours, family around them. You sit in the cockpit afterward, staring at the stars, wondering if you'd made a different choice whether it would have mattered.
+    The family doesn't blame you. That almost makes it worse.
+}
+-> transit.pass_time(1)

--- a/ship.ink
+++ b/ship.ink
@@ -1,6 +1,5 @@
 // TODO: ship modules degrade and need maintenance
 // TODO: contextual ship maintenance variety (drain lines, laundry, secure items, etc.)
-// TODO: passenger events when carrying passenger cargo
 
 VAR ShipClock = 0
 VAR ShipDestination = Transit
@@ -39,6 +38,9 @@ LIST P4Tasks = Relax, SleepRest
 // Remove events whose eligibility is fixed for the whole trip
 { ShipCargo == ():
     ~ Events -= CargoShift
+}
+{ not has_passenger_cargo(ShipCargo):
+    ~ Events -= PassengerEvents
 }
 ~ CargoDamagePct = 0
 Flying to {LocationData(destination, Name)} for {duration} days…

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -140,13 +140,16 @@ describe("Event triggering", () => {
   });
 
   it("events do not repeat within a trip", () => {
-    // Fire all 5 events by calling random_event repeatedly.
-    // After all 5 have fired, the pool should be empty and the
+    // Fire all general events by calling random_event repeatedly.
+    // After all have fired, the pool should be empty and the
     // dispatcher should fall through to ship_options.
     const story = createStory();
     story.variablesState["ShipCargo"] = new InkList();
-    // Give cargo so CargoShift is eligible
+    // Give non-passenger cargo so CargoShift is eligible
     story.variablesState["ShipCargo"] = L(story, "AllCargo.001_Plums");
+    // Remove passenger events (no passenger cargo — simulates what transit() does)
+    const passengerEvents = story.variablesState["PassengerEvents"];
+    story.variablesState["Events"] = story.variablesState["Events"].Without(passengerEvents);
     story.variablesState["ShipClock"] = 5;
     story.variablesState["ShipDestination"] = L(story, "AllLocations.Mars");
     story.variablesState["TripDuration"] = 10;


### PR DESCRIPTION
## Summary

- Adds four passenger-specific random events (Birthday, Complaint, Conversation, Medical Emergency) that only fire when carrying passenger cargo
- Introduces a `PassengerEvents` VAR to track the subset of passenger events — `Events -= PassengerEvents` removes them all at trip start when no passengers are aboard, so adding future events only requires updating two adjacent lines
- Medical Emergency is a moral dilemma: call a shuttle against the passenger's wishes (guaranteed safe, morale hit, +1 day) or let them stay with their family and gamble on the outcome (50/40/10 split for improve/worsen/death; odds improve with a future medical module)
- Stubs `has_medical_module()` returning `false` for connection to the module system (roadmap #5)
- Removes the `TODO: passenger events` comment from `ship.ink`

## Test plan

- [x] `npm run lint` — compiles cleanly
- [x] `npm test` — all 342 tests pass
- [x] Updated "events do not repeat" test to remove passenger events from pool when simulating a non-passenger trip (matches what `transit()` does)
- [ ] Manual: load passenger cargo (e.g. Tourists) and verify passenger events can trigger during transit
- [ ] Manual: load non-passenger cargo and verify no passenger events appear

Closes #4 on the transit roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)