### PR TITLE
Drop Morale stat, recreation menu, Entertainment & Wellness modules (#49)

### DIFF
--- a/.claude/rules/project-patterns.md
+++ b/.claude/rules/project-patterns.md
@@ -51,7 +51,7 @@ Tasks are threaded (`<-`) into `ship_options` using `CHOICE_COUNT()` caps:
 | P1   | Urgent (ship flip)                            | No cap                          |
 | P2   | Important (engine, urgent sleep)              | `TaskCap - p3_floor - p4_floor` |
 | P3   | Routine (paperwork, nav, cargo inspect, maintenance backlog) | `TaskCap - p4_floor` |
-| P4   | Recreation (relax, sleep)                     | `TaskCap`                       |
+| P4   | Rest (sleep)                                  | `TaskCap`                       |
 | P5   | Rest (skip day)                               | Only when no P1-P3 active       |
 
 Each tier uses a shuffle block for variety. `has_tier_tasks(tier)` centralizes eligibility checks.
@@ -89,14 +89,12 @@ Cargo inspections: `CargoCheckDueDay` (starts at 2), `CargoCheckPenaltyPct` → 
 - `ModuleData(module, stat)` lookup, `get_module_condition()`/`set_module_condition()` accessors
 - `is_module_active(module)` — installed AND condition >= 50
 - `get_drone_capacity(module)` — 2 at 75%+, 1 at 50-74%, 0 below 50%
-- `module_auto_tasks` tunnel: runs in `next_day()` and at trip start; handles all modules — drones (engine/ship task split, stale-first), AutoNav, CargoMgmt, WellnessSuite
+- `module_auto_tasks` tunnel: runs in `next_day()` and at trip start; handles all modules — drones (engine/ship task split, stale-first), AutoNav, CargoMgmt
 - `RefurbishedModules` VAR tracks 80% max cap; `get_module_max_condition()` enforces it
 - Module maintenance tasks in `ModuleMaintTasks` LIST: 2 tasks per module; `module_tasks_for(mod)` returns a module's task pair; `available_module_tasks()` returns the union across installed modules
 - Narrative lookup: `MaintName(task)`, `MaintComplete(task)`, `MaintFatigued(task)`, `MaintOverdue(task)` — one function per text type, switch block covering all tasks from all three LISTs
 - Purchase UI: `ship_upgrades` knot with buy new/refurb/repair options for modules; `engine_upgrades` stitch for engine purchases (next tier only, manufacturer gated by location)
 - Engine upgrade system: `EngPrice` stat in `EngineStats`, `RefurbishedEngine` VAR (boolean), `get_engine_max_condition()` in functions.ink mirrors `get_module_max_condition()` pattern; manufacturer availability via `manufacturer_available_here(mfg)` checked against `here`
-- Entertainment System: `apply_recreation_bonus(base)` function in ship.ink — +50% morale at 75%+ condition; new P4 tasks `VideoGames`/`ListenMusic` gated by `is_module_active(Entertainment)`
-- WellnessSuite wires `has_medical_module()` in events.ink
 - AutoNav (500€): advances `NavCheckDueDay = TripDay + 3` on auto-complete; 75%+ every check, 50-74% even `TripDay` only
 - CargoMgmt (700€): handles inspections + paperwork with 1-task-per-day limit; inspections prioritized (expire same day), paperwork fills remaining days; advances `CargoCheckDueDay = TripDay + get_cargo_check_interval()` on inspection; 75%+ every due day, 50-74% even `TripDay` only
 - PassengerModule (tiered, unique upgrade path): uses `PassengerModuleTier` VAR (0=not installed, 1-3) rather than a single condition gate; separate `passenger_module_upgrades` stitch excluded from `browse_module_list`; cargo gated by `InstalledModules ? PassengerModule` in `cargo_is_available`

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -365,10 +365,10 @@ The transit day presents tasks to the player via a priority-based selection syst
 | P1 | Urgent | Always shown when applicable. No cap. |
 | P2 | Important | Shown when stat thresholds met. Shuffled. Capped at `TaskCap - p3_floor - p4_floor`. |
 | P3 | Routine | Shown on schedule or when relevant. Shuffled. Capped at `TaskCap - p4_floor`. |
-| P4 | Recreation | Fills remaining slots. Shuffled. Capped at `TaskCap`. |
+| P4 | Rest | Fills remaining slots. Capped at `TaskCap`. |
 | P5 | Rest | Shown only when no P1–P3 tasks are active. |
 
-`TaskCap` (default 7) controls the maximum number of top-level tasks. P3 and P4 each have a floor of 1 slot (if eligible tasks exist in that tier), ensuring the player always has at least one routine task and one recreation option.
+`TaskCap` (default 7) controls the maximum number of top-level tasks. P3 has a floor of 1 slot (if eligible tasks exist), ensuring the player always has at least one routine task.
 
 ### Threading + CHOICE_COUNT() Pattern
 
@@ -389,7 +389,6 @@ Shuffle blocks randomize which tasks within a tier get offered first, providing 
 Related tasks are collapsed into single top-level entries that expand into sub-menus with flavor text:
 
 - **Sleep** (P2 when fatigue ≥ 70, P4 when 30–69) → nap (1 AP), full sleep (2 AP)
-- **Relax** (P4, always) → cook a special meal (2 AP), workout (1 AP), movie (2 AP), video games (1 AP, Entertainment active), listen to music (1 AP, Entertainment active)
 - **Ship maintenance** (P3, when backlog has tasks) → shows all backlog tasks (1 AP each), stale tasks marked "overdue"
 - **Engine care** (P2, when condition < 80) → run diagnostics (2 AP)
 
@@ -427,7 +426,7 @@ When fatigue is 70 or above, work tasks are subject to a dice roll that can caus
 - **Degraded** (ship flip, engine tune, backlog maintenance) — The task completes but with a reduced effect. Ship flip adds a fuel penalty. Engine tune restores +8 instead of +15. Backlog maintenance restores +1 instead of +3.
 - **Fail + retry** (nav check, cargo inspection, paperwork) — The task doesn't count. The due day is not advanced, so the task remains available for retry. AP is still spent.
 
-Only "work" tasks use `fatigue_check()`. Sleep, recreation, eating, and rest are unaffected.
+Only "work" tasks use `fatigue_check()`. Sleep and rest are unaffected.
 
 `is_overtired()` is still used for UI concerns (P2 sleep threshold, task offering logic). `fatigue_check()` is used for task outcome resolution.
 
@@ -443,8 +442,6 @@ Random events are P0 interruptions that fire during transit, bypassing the task 
 - **Passenger events** — only eligible when the player has passenger cargo (static check at trip start)
 
 **Passenger event eligibility:** The `PassengerEvents` VAR holds the subset of events that require passengers. In `transit()`, `Events -= PassengerEvents` removes all passenger events in one operation when no passenger cargo is aboard. To add a new passenger event, add it to both the `Events` LIST and the `PassengerEvents` VAR (they are adjacent in `events.ink`).
-
-**`has_medical_module()`:** Returns `is_module_active(WellnessSuite)`. Used by the medical emergency event to improve patient outcomes — better recovery odds and no possibility of a fatal outcome when the suite is active (condition >= 50%).
 
 **Passenger satisfaction impacts:** All four passenger events and the coffee machine event modify `PassengerSatisfaction` (guarded by `InstalledModules ? PassengerModule`). See the event tables in `events.ink` for the specific values. The coffee machine event affects satisfaction if passengers are present (the lack of coffee hits harder with an audience).
 
@@ -493,10 +490,6 @@ All module daily behavior runs via the `module_auto_tasks` tunnel, called from `
 - **Auto-Nav Computer** (500€) — auto-completes nav checks. Full (75%+): completes every check. Reduced (50-74%): completes on even `TripDay` only. Advances `NavCheckDueDay = TripDay + 3` on completion.
 - **Cargo Management System** (700€) — handles both cargo inspections and paperwork (1 task/day, inspections prioritized). Full (75%+): completes every task due. Reduced (50-74%): completes on even `TripDay` only. Inspections take priority because they expire (day-of only); paperwork persists until delivery. Advances `CargoCheckDueDay = TripDay + get_cargo_check_interval()` on inspection completion.
 
-- **Entertainment System** (400€) — improves recreation. Full (75%+): all recreation (cooking, workout, movie, video games, music) gets a +50% morale bonus via `apply_recreation_bonus(base)`. The bonus uses integer math: `base + base / 2`. Reduced (50-74%): video games and music are available (module is active), but no morale bonus. Below 50%: offline, no extra options. Video games and music appear inside the "Take a break" → `relax_options` sub-menu when Entertainment is active (not as standalone P4 choices). They are gated with `{ is_module_active(Entertainment) }` inline choice guards inside `relax_options`.
-
-- **Wellness Suite** (500€) — daily fatigue/morale benefit and medical emergency improvement. Full (75%+): -5 fatigue, +2 morale per day. Reduced (50-74%): -3 fatigue, +1 morale. Applied in `module_auto_tasks` with narrative flavor text (gym, autodoc, sunlight simulator, therapy, haircut). Also wires `has_medical_module()` → `is_module_active(WellnessSuite)` to improve medical emergency outcomes.
-
 - **Passenger Module** (tiered, separate upgrade path) — gates passenger cargo and drives the satisfaction system. Unlike other modules, this has a `PassengerModuleTier` VAR (0=not installed, 1-3=tier) and a separate purchase/upgrade UI stitch (`passenger_module_upgrades`) that is linked from `upgrade_menu` but excluded from the standard `browse_module_list`. Tier is upgraded sequentially (T0→T1→T2→T3); pricing is cumulative (200/400/800€ total, delta charged per upgrade). The refurbished option is only available at initial install (T0→T1). Passive satisfaction bonus activates at T2+.
 
 ### Module Maintenance (Two Layers)
@@ -524,7 +517,6 @@ Port menu option `[Ship upgrades]` diverts to `ship_upgrades` in `modules.ink`. 
 8. Wire module-specific behavior:
    - For maintenance auto-complete or daily passive effects: add a stitch in `module_auto_tasks` (modules.ink)
    - For task list effects: gate tasks with `is_module_active(Module)` in `ship_options`
-   - For event/combat effects: update the relevant function (e.g., `has_medical_module()`)
 
 ---
 

--- a/docs/player-guide.md
+++ b/docs/player-guide.md
@@ -87,9 +87,9 @@ This might seem backwards, but it makes sense: the outer planets are rich in raw
 
 Flying between ports isn't just sitting around. You've got a ship to maintain and paperwork to file. Each day in transit, you'll spend **action points (AP)** on various tasks. You start each day with 6 AP, and everything costs 1 or 2 AP.
 
-Your task list adapts to your ship's condition each day. Urgent matters appear first — a ship that needs flipping or an engine that's struggling will be at the top of your list. Routine work fills in below, and recreation options round out the bottom. On a quiet day with nothing pressing, you can call it a day and rest if you'd rather skip the busywork.
+Your task list adapts to your ship's condition each day. Urgent matters appear first — a ship that needs flipping or an engine that's struggling will be at the top of your list. Routine work fills in below. On a quiet day with nothing pressing, you can call it a day and rest if you'd rather skip the busywork.
 
-Some tasks open into sub-options when you select them. Choosing "Take a break" lets you pick between cooking a special meal, exercising, watching a movie, or (if you have the Entertainment System) playing video games or listening to music. Choosing "Get some rest" offers a quick nap or a full sleep cycle. You can always back out without spending AP if you change your mind.
+Some tasks open into sub-options when you select them. Choosing "Get some rest" offers a quick nap or a full sleep cycle. You can always back out without spending AP if you change your mind.
 
 ### The Ship Flip
 
@@ -115,16 +115,13 @@ Your ship needs constant attention. Each day in transit, four new maintenance ta
 
 If you skip a task, it sticks around and gets flagged as overdue. Skip it again and it resolves on its own — badly. That engine tune you put off? It's now a grinding noise and a hit to your engine condition. Tasks you stay on top of keep the ship running smoothly; tasks you ignore cause problems.
 
-**Engine condition** affects fuel costs. A degraded engine burns more fuel — at 80% condition, fuel costs are 10% higher. **Ship condition** affects morale — a dirty ship makes you miserable faster.
+**Engine condition** affects fuel costs. A degraded engine burns more fuel — at 80% condition, fuel costs are 10% higher.
 
 When you reach port, you can pay for professional repairs: an engine overhaul or a cleaning service to restore conditions to 100%. The price depends on how much work needs doing.
 
-### Fatigue and Morale
+### Fatigue
 
-You have two personal stats to manage:
-
-- **Fatigue** builds up as you work. Sleep (2 AP) resets it fully; naps (1 AP) take the edge off. If you push too hard, you'll start making mistakes — sloppy engine work, botched navigation checks, customs forms you have to redo. The more exhausted you are, the more likely things go wrong. You'll see warnings when fatigue is getting dangerous, and at extreme levels almost everything you try will go sideways.
-- **Morale** decays slowly each day, faster if your ship is a mess. Recreation activities (cooking a meal, watching a movie, exercising) restore it. If morale drops too low, you'll lose AP each day.
+**Fatigue** builds up as you work. Sleep (2 AP) resets it fully; naps (1 AP) take the edge off. If you push too hard, you'll start making mistakes — sloppy engine work, botched navigation checks, customs forms you have to redo. The more exhausted you are, the more likely things go wrong. You'll see warnings when fatigue is getting dangerous, and at extreme levels almost everything you try will go sideways.
 
 The early game is a balancing act: there's a lot of work to do and not enough hours. As you upgrade your ship, automation handles more of the busywork, leaving more time for you.
 
@@ -139,21 +136,6 @@ When you're carrying passengers, you'll encounter additional events — birthday
 To carry passengers at all, you need a **Passenger Module** installed (see below). How you treat them during the trip determines whether you earn a bonus or take a cut on delivery.
 
 Being exhausted makes emergencies worse. A fatigued repair takes longer and may cause additional damage. Rest before you need it, not after something goes wrong.
-
-### Cooking
-
-When you choose "Take a break" during transit, one option is to **cook a special meal** (2 AP, +12 morale). Each time, you'll see a selection of four recipes drawn randomly from a diverse list — curry, pho, jollof rice, bibimbap, tamales, and more. Pick one and read a short scene about preparing it. It's the most morale-effective recreation option at 2 AP.
-
-At port, visit **Go shopping** to browse fresh local ingredients. Each port stocks two or three specialty items that aren't available elsewhere:
-
-- **Earth** — Fresh strawberries, wagyu steak
-- **Luna** — Hydroponic herb bundle, cave-aged cheese
-- **Mars** — Greenhouse peppers, Olympus honey
-- **Ceres** — Asteroid truffles, belt-brewed sake
-- **Ganymede** — Ganymede dairy ice cream, Europan sea salt
-- **Titan** — Titan-cured meats, cryo-preserved berries
-
-Ingredients cost 15–25 € each. When you have an ingredient in your galley, it appears as a guaranteed extra choice in the cooking menu during your next transit — with a higher morale boost (+15) than standard recipes. Once you cook with it, it's gone.
 
 ---
 
@@ -170,10 +152,6 @@ At any port, you can visit the **Ship upgrades** menu to buy modules that automa
 **Auto-Nav Computer** (500€) — Automatically handles the navigation check that comes due every three days. At full condition (75%+), it handles every check. At reduced condition (50-74%), it handles every other check — you'll need to cover the rest manually. Below 50%, it goes offline. When the auto-nav handles a check, the task won't appear in your task list that day.
 
 **Cargo Management System** (700€) — Automatically handles both cargo inspections and paperwork. It can only do one task per day, so it prioritizes inspections (which expire if you miss the window) and files paperwork on quieter days. At full condition (75%+), it handles everything it can. At reduced condition (50-74%), it only manages to act every other day. Below 50%, it goes offline.
-
-**Entertainment System** (400€) — Upgrades your recreation options and improves how rewarding downtime feels. At full condition (75%+), all recreation activities give a 50% morale bonus, and two new options appear inside "Take a break": "Play video games" (+10 morale) and "Listen to music" (+5 morale). At reduced condition (50-74%), the new options are available but there's no bonus to any recreation. Below 50%, it goes offline and everything reverts to baseline.
-
-**Wellness Suite** (500€) — A combined gym, autodoc, drug printer (supplements, painkillers, stimulants), sunlight simulator, remote therapy service, and yes — a working hair trimmer. Each day the suite is active, it reduces your fatigue by 5 and boosts morale by 2 (at full condition, 75%+), or 3 fatigue / 1 morale at reduced condition (50-74%). It also improves outcomes when you're carrying a passenger who has a medical emergency — better odds of recovery, and no possibility of a fatal outcome. Below 50%, it goes offline.
 
 **Passenger Module** — Required to carry passengers. Comes in three tiers (installed sequentially):
 
@@ -218,7 +196,7 @@ Modules need occasional attention:
 
 With both drone modules at full effectiveness, they handle 4 maintenance tasks per day — 2 engine, 2 ship. Combined with a task or two of manual work, you can keep on top of the daily backlog easily. Without drones, the backlog accumulates and penalties start mounting.
 
-The other four modules free up AP and improve your quality of life in ways that compound over a long trip. The Auto-Nav and Cargo Management systems handle routine tasks automatically, leaving more time for sleep and recreation. The Entertainment System makes that recreation more rewarding. The Wellness Suite chips away at fatigue and morale every day — not dramatically, but steadily.
+The other modules free up AP and improve your quality of life in ways that compound over a long trip. The Auto-Nav and Cargo Management systems handle routine tasks automatically, leaving more time for sleep and other priorities.
 
 The investment pays for itself quickly: fewer condition penalties mean less money spent on port repairs and fuel (since engine condition affects fuel costs). Plus, the freed-up AP lets you focus on the things that keep you sharp for the long haul.
 

--- a/events.ink
+++ b/events.ink
@@ -91,15 +91,6 @@ VAR PassengerEvents = (PassengerBirthday, PassengerComplaint, PassengerConversat
 
 /*
 
-    Medical Module Check
-    Returns true if the Wellness Suite is installed and active (condition >= 50).
-
-*/
-=== function has_medical_module()
-~ return is_module_active(WellnessSuite)
-
-/*
-
     Micrometeorite Strike
     A micrometeorite impacts the hull. Must be repaired immediately.
     Fatigue check: failure costs extra AP and adds a fuel penalty.
@@ -222,7 +213,6 @@ They press {reward} € into your hand before you undock. "You saved us weeks ou
 = distress_help_partial
 You pass over a kit of spare parts and a few canisters of fuel through the airlock. Not a full fix, but enough to get them moving.
 ~ PlayerBankBalance += 150
-~ Morale = MIN(Morale + 10, 100)
 They thank you warmly. {150} € and the knowledge you did something good.
 -> transit.pass_time(2)
 
@@ -290,17 +280,14 @@ A grinding noise from the galley, then silence. You investigate. The coffee mach
 
 = coffee_fix
 You pull the machine apart, diagnose a clogged heating element, and spend two hours putting it back together right. The first cup it makes is mediocre. The second one is perfect.
-~ Morale = MIN(Morale + 5, 100)
 { has_passenger_cargo(ShipCargo) and InstalledModules ? PassengerModule:
     ~ PassengerSatisfaction = MIN(PassengerSatisfaction + 3, 100)
 }
 -> transit.pass_time(2)
 
 = coffee_ignore
-~ Morale = MAX(Morale - 15, 0)
 You try to convince yourself you don't need it. You absolutely need it. The rest of the day is worse for it.
 { has_passenger_cargo(ShipCargo):
-    ~ Morale = MAX(Morale - 5, 0)
     Your passengers are not happy about it either. You get three separate complaints before lunch.
     { InstalledModules ? PassengerModule:
         ~ PassengerSatisfaction = MAX(PassengerSatisfaction - 3, 0)
@@ -321,7 +308,6 @@ One of your passengers flags you down in the corridor. Turns out it's their birt
 + [Throw a small celebration — break out some rations and make it festive]
     -> birthday_celebrate
 + [Wish them a happy birthday and get back to work]
-    ~ Morale = MIN(Morale + 5, 100)
     You wish them well with a genuine smile. They seem touched that you remembered. Small gestures count for something out here.
     { InstalledModules ? PassengerModule:
         ~ PassengerSatisfaction = MIN(PassengerSatisfaction + 3, 100)
@@ -332,13 +318,11 @@ One of your passengers flags you down in the corridor. Turns out it's their birt
 You clear a table in the common area, dig out something that passes for cake mix, and round up the other passengers.
 { fatigue_check():
     You're running on fumes and it shows. The "celebration" is half-hearted — you burn the cake and can barely keep your eyes open through the singing. It's the thought that counts, but only just.
-    ~ Morale = MIN(Morale + 5, 100)
     { InstalledModules ? PassengerModule:
         ~ PassengerSatisfaction = MIN(PassengerSatisfaction + 3, 100)
     }
 - else:
     It's nothing fancy, but the passengers are laughing and trading stories, and for a little while the ship feels less like a cargo hauler and more like somewhere people actually want to be.
-    ~ Morale = MIN(Morale + 10, 100)
     { InstalledModules ? PassengerModule:
         ~ PassengerSatisfaction = MIN(PassengerSatisfaction + 8, 100)
     }
@@ -358,7 +342,6 @@ A passenger corners you outside the cockpit. The air recycler is making a noise 
 + [See what you can do to fix their complaints]
     -> complaint_accommodate
 + [Apologise but explain this is a cargo ship, not a cruise liner]
-    ~ Morale = MIN(MAX(Morale - 5, 0), 100)
     You're sympathetic but honest — this is a working freighter, not a passenger vessel. They're not happy, but they accept it. The mood aboard drops a little.
     { InstalledModules ? PassengerModule:
         ~ PassengerSatisfaction = MAX(PassengerSatisfaction - 5, 0)
@@ -373,7 +356,6 @@ You head down to check the recycler and tweak the heating.
         ~ PassengerSatisfaction = MIN(PassengerSatisfaction + 2, 100)
     }
 - else:
-    ~ Morale = MIN(Morale + 5, 100)
     The recycler had a loose panel — easy fix once you found it. You adjust the heating and throw in an extra blanket for good measure. The passenger seems genuinely grateful.
     { InstalledModules ? PassengerModule:
         ~ PassengerSatisfaction = MIN(PassengerSatisfaction + 5, 100)
@@ -393,7 +375,6 @@ You head down to check the recycler and tweak the heating.
 You're running through a systems check when one of your passengers drifts into the cockpit. They're not complaining — they're just curious. They ask about the ship, the route, what it's like out here.
 
 + [Chat with them for a while]
-    ~ Morale = MIN(Morale + 5, 100)
     ~ Fatigue = MAX(Fatigue - 5, 0)
     You lean back and talk. They're good company — asking questions, listening to the answers, sharing their own stories. By the time they head back to their berth, you feel lighter than you have in days.
     { InstalledModules ? PassengerModule:
@@ -435,7 +416,6 @@ You look at the shuttle ETA on your console, then at the family huddled in the d
 
 = medical_call_shuttle
 You make the call. The passenger argues, then pleads, but you hold firm. When the shuttle docks, the medics transfer them quickly and professionally. The family watches from the airlock window as the shuttle pulls away.
-~ Morale = MIN(MAX(Morale - 10, 0), 100)
 ~ ShipClock = ShipClock + 1
 { InstalledModules ? PassengerModule:
     ~ PassengerSatisfaction = MAX(PassengerSatisfaction - 10, 0)
@@ -445,7 +425,6 @@ The ship is quiet afterward. You did the right thing — you know that. But the 
 
 = medical_stay_aboard
 You tell the shuttle to stand by and turn back to the passenger. "Alright. You're staying. But you do exactly what I tell you."
-~ Morale = MIN(Morale + 5, 100)
 The family crowds in, grateful and terrified in equal measure. You dig out the first aid kit and do everything you can.
 -> medical_stay_outcome
 
@@ -453,10 +432,6 @@ The family crowds in, grateful and terrified in equal measure. You dig out the f
 ~ temp outcome_roll = RANDOM(1, 100)
 ~ temp improve_chance = 50
 ~ temp worsen_chance = 90
-{ has_medical_module():
-    ~ improve_chance = 75
-    ~ worsen_chance = 100  // no death possible with medical module
-}
 {
 - outcome_roll <= improve_chance:
     Over the next few hours, colour returns to their face. Their breathing steadies. By evening they're sitting up, sipping water, and arguing with their spouse about whether they should have taken the shuttle. You take that as a good sign.
@@ -464,14 +439,12 @@ The family crowds in, grateful and terrified in equal measure. You dig out the f
         ~ PassengerSatisfaction = MIN(PassengerSatisfaction + 10, 100)
     }
 - outcome_roll <= worsen_chance:
-    ~ Morale = MIN(MAX(Morale - 10, 0), 100)
     They don't improve. If anything, they get worse — fever spikes, breathing goes shallow. You do what you can, but you're a pilot, not a doctor. They're stable enough to make it to port, but it's going to be a rough ride. You can't shake the feeling you made the wrong call.
     { InstalledModules ? PassengerModule:
         ~ PassengerSatisfaction = MAX(PassengerSatisfaction - 5, 0)
     }
 - else:
-    // 10% chance without medical module — the worst outcome
-    ~ Morale = MIN(MAX(Morale - 20, 0), 100)
+    // 10% chance — the worst outcome
     You do everything right. You follow every step in the emergency manual. It's not enough.
     They pass quietly in the small hours, family around them. You sit in the cockpit afterward, staring at the stars, wondering if you'd made a different choice whether it would have mattered.
     The family doesn't blame you. That almost makes it worse.

--- a/modules.ink
+++ b/modules.ink
@@ -11,8 +11,6 @@
 - CleaningDrones: ~ return module_row(stat, "Cleaning Drones", 600, "Auto-complete ship maintenance tasks")
 - AutoNav:        ~ return module_row(stat, "Auto-Nav Computer", 500, "Auto-complete navigation checks")
 - CargoMgmt:      ~ return module_row(stat, "Cargo Management", 700, "Auto-complete cargo inspections and paperwork")
-- Entertainment:  ~ return module_row(stat, "Entertainment System", 400, "Improved recreation and morale boosts")
-- WellnessSuite:  ~ return module_row(stat, "Wellness Suite", 500, "Daily health benefits and emergency medical care")
 - PassengerModule: ~ return module_row(stat, "Passenger Module", 200, "Passenger berths and facilities")
 }
 ~ return 0
@@ -43,8 +41,6 @@
 - CleaningDrones: ~ return CleaningDronesCondition
 - AutoNav:        ~ return AutoNavCondition
 - CargoMgmt:      ~ return CargoMgmtCondition
-- Entertainment:  ~ return EntertainmentCondition
-- WellnessSuite:  ~ return WellnessSuiteCondition
 - PassengerModule: ~ return PassengerModuleCondition
 }
 ~ return 0
@@ -61,8 +57,6 @@
 - CleaningDrones: ~ CleaningDronesCondition = value
 - AutoNav:        ~ AutoNavCondition = value
 - CargoMgmt:      ~ CargoMgmtCondition = value
-- Entertainment:  ~ EntertainmentCondition = value
-- WellnessSuite:  ~ WellnessSuiteCondition = value
 - PassengerModule: ~ PassengerModuleCondition = value
 }
 
@@ -215,10 +209,6 @@
 - NavGyroCalib:   ~ return AutoNav
 - CargoSensor:    ~ return CargoMgmt
 - CargoSealCheck: ~ return CargoMgmt
-- EntWiring:      ~ return Entertainment
-- EntDisplayClean: ~ return Entertainment
-- WellSanitize:   ~ return WellnessSuite
-- WellCalib:      ~ return WellnessSuite
 - PaxLifeSupp:    ~ return PassengerModule
 - PaxBerthClean:  ~ return PassengerModule
 }
@@ -231,8 +221,6 @@
 - CleaningDrones: ~ return (ClnDroneBrush, ClnDroneFilter)
 - AutoNav:        ~ return (NavChipFlush, NavGyroCalib)
 - CargoMgmt:      ~ return (CargoSensor, CargoSealCheck)
-- Entertainment:  ~ return (EntWiring, EntDisplayClean)
-- WellnessSuite:  ~ return (WellSanitize, WellCalib)
 - PassengerModule: ~ return (PaxLifeSupp, PaxBerthClean)
 }
 ~ return ()
@@ -270,9 +258,6 @@
 }
 { InstalledModules ? CargoMgmt:
     -> process_cargo_mgmt ->
-}
-{ InstalledModules ? WellnessSuite:
-    -> process_wellness ->
 }
 ->->
 
@@ -392,32 +377,6 @@
                 ~ PaperworkDone = PaperworkDone + 1
                 The cargo management system pings — it managed to file a chunk of paperwork, but it's taking longer than it should. You make a mental note to have a tech look at it next time you're in port.
             }
-        }
-    }
-}
-->->
-
-= process_wellness
-~ temp well_cond = get_module_condition(WellnessSuite)
-{ well_cond >= 75:
-    ~ Fatigue = MAX(Fatigue - 5, 0)
-    ~ Morale = MIN(Morale + 2, 100)
-    { shuffle:
-    -   You squeeze in a quick session in the ship's gym. Your body thanks you.
-    -   The autodoc dispenses your daily vitamin pack. It's the little things.
-    -   You spend twenty minutes under the sunlight simulator. Somehow it actually helps.
-    -   You check in with the remote therapy service. Just talking helps more than you expected.
-    -   The hair trimmer takes care of business. You look almost human again.
-    -   You grab the painkiller the autodoc recommends for the ache in your shoulder. Problem solved.
-    }
-- else:
-    { well_cond >= 50:
-        ~ Fatigue = MAX(Fatigue - 3, 0)
-        ~ Morale = MIN(Morale + 1, 100)
-        { shuffle:
-        -   The gym equipment is acting up again, but you manage a short session.
-        -   The autodoc is running slow, but eventually dispenses your supplements.
-        -   The sunlight simulator flickers a bit, but you take what you can get.
         }
     }
 }

--- a/port.ink
+++ b/port.ink
@@ -1,7 +1,5 @@
 VAR PortCargo = ()
 
-LIST FreshIngredientStats = IngName, IngDesc, IngPrice, IngPort
-
 /*
 
     Arrive in Port
@@ -15,10 +13,10 @@ LIST FreshIngredientStats = IngName, IngDesc, IngPrice, IngPort
 
 Welcome to {LocationData(port, Name)}!
 { shuffle:
--   The smell of real food hits you the moment you dock. Somewhere in this station, something is cooking on an actual stove.
--   You're already thinking about what you can eat that isn't a ration packet.
--   After days of reconstituted everything, the station smells like a restaurant. You stand in the docking bay for a moment, just breathing.
--   Your first stop, before cargo, before fuel, is the station commissary. You need something fresh.
+-   The station hum is almost soothing after days of engine drone. You stand in the docking bay for a moment, just listening.
+-   Gravity again. Your knees complain, but the rest of you is grateful.
+-   The bustle of the docking bay washes over you — other ships, other crews, other stories. It's good to be somewhere.
+-   You take a breath of station air. Recycled, sure, but different recycled. That counts for something.
 }
 
 - (port_opts)
@@ -30,7 +28,6 @@ Welcome to {LocationData(port, Name)}!
 + [Buy fuel] -> fuel_station
 + { EngineCondition < get_engine_max_condition() or ShipCondition < 100 } [Ship repairs] -> repair_services
 + [Ship upgrades] -> ship_upgrades
-+ [Go shopping] -> go_shopping
 + [Ship out!] -> ship_out
 + { DEBUG } [\[DEBUG\] Cheats] -> debug_cheats
 - -> port_opts
@@ -483,82 +480,3 @@ You have {ShipFuel} fuel, and a total mass of {total_mass(ShipCargo)}t.
 === function get_fuel_purchase_cost(amount)
 ~ return FLOOR(amount * get_fuel_price(here))
 
-/*
-
-    Fresh Ingredient Data
-    Lookup table for ingredients available at port. Stats: IngName, IngDesc, IngPrice, IngPort.
-    IngPort is the AllLocations value where the item is sold.
-    Items map to fresh meal entries in ship.ink's do_cook() and recipe_name().
-
-*/
-=== function FreshIngredientData(item, stat)
-{ item:
-- EarthStrawberries: ~ return ing_row(stat, "Fresh strawberries",     "Makes strawberry shortcake", 20, Earth)
-- EarthWagyu:        ~ return ing_row(stat, "Wagyu steak",             "Makes pan-seared wagyu",     25, Earth)
-- LunaHerbs:         ~ return ing_row(stat, "Hydroponic herb bundle",  "Makes herb-crusted fish",    15, Luna)
-- LunaCheese:        ~ return ing_row(stat, "Cave-aged cheese",        "Makes cheese fondue",        20, Luna)
-- MarsPeppers:       ~ return ing_row(stat, "Greenhouse peppers",      "Makes stuffed peppers",      15, Mars)
-- MarsHoney:         ~ return ing_row(stat, "Olympus honey",           "Makes honey-glazed ribs",    20, Mars)
-- CeresTruffles:     ~ return ing_row(stat, "Asteroid truffles",       "Makes truffle risotto",      25, Ceres)
-- CeresSake:         ~ return ing_row(stat, "Belt-brewed sake",        "Makes sake-glazed salmon",   20, Ceres)
-- GanymedeIceCream:  ~ return ing_row(stat, "Ganymede dairy ice cream","Makes ice cream sundae",     15, Ganymede)
-- GanymedeSalt:      ~ return ing_row(stat, "Europan sea salt",        "Makes salt-crusted bread",   20, Ganymede)
-- TitanMeats:        ~ return ing_row(stat, "Titan-cured meats",       "Makes charcuterie board",    25, Titan)
-- TitanBerries:      ~ return ing_row(stat, "Cryo-preserved berries",  "Makes berry cobbler",        20, Titan)
-}
-~ return 0
-
-=== function ing_row(stat, name, desc, price, port)
-{ stat:
-- IngName:  ~ return name
-- IngDesc:  ~ return desc
-- IngPrice: ~ return price
-- IngPort:  ~ return port
-}
-~ return 0
-
-// Returns the set of fresh ingredients available at the given port.
-// Recursively filters sourceList, keeping items whose IngPort matches port.
-=== function ingredients_at(port, sourceList)
-~ temp item = pop(sourceList)
-{ item:
-    { FreshIngredientData(item, IngPort) == port:
-        ~ return item + ingredients_at(port, sourceList)
-    - else:
-        ~ return ingredients_at(port, sourceList)
-    }
-}
-~ return ()
-
-/*
-
-    Go Shopping
-    Browse and buy fresh ingredients available at the current port.
-    Purchased items appear as guaranteed cooking options during transit.
-
-*/
-=== go_shopping
-The station market has a small fresh section — real food, grown locally.
-- (shop_menu)
-~ temp stock = ingredients_at(here, LIST_ALL(FreshIngredients)) - PurchasedIngredients
-- (shop_top)
-~ temp item = pop(stock)
-{ item:
-    <- shop_item_choice(item)
-    -> shop_top
-}
--
-+ [Back] -> arrive_in_port.port_opts
-- -> shop_menu
-
-= shop_item_choice(item)
-~ temp price = FreshIngredientData(item, IngPrice)
-~ temp name = FreshIngredientData(item, IngName)
-~ temp desc = FreshIngredientData(item, IngDesc)
-+ { PlayerBankBalance >= price } [{ name } — {price} €]
-    ~ PlayerBankBalance -= price
-    ~ PurchasedIngredients += item
-    You pick up the {name}. {desc}. It goes in the galley cooler.
-    -> shop_menu
-+ { PlayerBankBalance < price } [{ name } — {price} € #UNCLICKABLE]
-    -> shop_menu

--- a/ship.ink
+++ b/ship.ink
@@ -7,7 +7,7 @@ VAR ActionPointsMax = 6
 // bounds in sync. Add an entry here when adding a task to a tier's shuffle.
 LIST P2Tasks = EngineMaintenance, UrgentSleep
 LIST P3Tasks = Paperwork, NavCheck, CargoInspect, MaintBacklog, PassengerTask
-LIST P4Tasks = Relax, SleepRest
+LIST P4Tasks = SleepRest
 
 // Passenger task pool — 12 tasks in 3 tone categories.
 // Tone category VARs control weighted random selection in pick_passenger_task.
@@ -16,7 +16,6 @@ LIST PassengerTasks = PaxShower, PaxQuarters, PaxAirQuality, PaxRations, PaxMovi
 VAR NegativePaxTasks = (PaxShower, PaxQuarters, PaxAirQuality, PaxRations)
 VAR MixedPaxTasks = (PaxMovieNight, PaxMealService, PaxGameNight, PaxExercise)
 VAR PositivePaxTasks = (PaxObsDeck, PaxKaraoke, PaxStargazing, PaxCocktails)
-LIST Recipes = Curry, Pho, JollofRice, Pupusas, Borscht, Bibimbap, Tamales, DimSum, Shakshuka, Pierogi, Feijoada, Bannock
 
 /*
 
@@ -137,16 +136,9 @@ Flying to {LocationData(destination, Name)} for {duration} days…
 ~ p3_loops++
 { p3_loops < LIST_COUNT(LIST_ALL(P3Tasks)) and CHOICE_COUNT() < p3_cap: -> p3_shuffle }
 
-// P4: Recreation — shuffle, respects p4_cap
+// P4: Rest — only sleep when fatigued
 - (p4_offer)
-~ temp p4_loops = 0
-- (p4_shuffle)
-{ shuffle:
-    - { CHOICE_COUNT() < p4_cap: <- task_relax }
-    - { CHOICE_COUNT() < p4_cap and Fatigue >= 30 and Fatigue < 70: <- task_sleep_rest }
-}
-~ p4_loops++
-{ p4_loops < LIST_COUNT(LIST_ALL(P4Tasks)) and CHOICE_COUNT() < p4_cap: -> p4_shuffle }
+{ CHOICE_COUNT() < p4_cap and Fatigue >= 30 and Fatigue < 70: <- task_sleep_rest }
 
 // P5: Rest — only when no P1–P3 tasks are active
 ~ temp has_obligations = has_tier_tasks(1) or has_tier_tasks(2) or has_tier_tasks(3)
@@ -194,9 +186,6 @@ Flying to {LocationData(destination, Name)} for {duration} days…
 
 = task_maintenance
 + [Ship maintenance — {LIST_COUNT(Backlog)} tasks{ has_overdue_tasks(): (overdue!)}] -> maintenance_options
-
-= task_relax
-+ [Take a break] -> relax_options
 
 = task_rest
 + [Call it a day — skip remaining {AP} AP] -> do_rest
@@ -248,33 +237,6 @@ Engine: {EngineCondition}% / Ship: {ShipCondition}%
 - else:
     + [{ MaintName(task) } (1 AP)] -> do_maintenance(task)
 }
-
-= relax_options
-What sounds good right now?
-+ [Cook a special meal (2 AP)] -> cook_options
-+ [Quick workout (1 AP)] -> do_recreation(1, 8)
-+ [Watch a movie (2 AP)] -> do_recreation(2, 15)
-+ { is_module_active(Entertainment) } [Play video games (1 AP)] -> do_video_games
-+ { is_module_active(Entertainment) } [Listen to music (1 AP)] -> do_listen_music
-+ [Never mind] -> ship_options
-
-= cook_options
-What do you feel like making?
-~ temp cook_pool = PurchasedIngredients
-~ temp fill_count = MAX(4 - LIST_COUNT(PurchasedIngredients), 0)
-~ cook_pool += list_random_subset_of_size(LIST_ALL(Recipes), fill_count)
-- (cook_top)
-~ temp meal = pop(cook_pool)
-{ meal:
-    <- cook_choice(meal)
-    -> cook_top
-}
--
-+ [Never mind] -> relax_options
-
-= cook_choice(meal)
-+ [{ recipe_name(meal) }{ PurchasedIngredients ? meal:  (fresh ingredients)}]
-    -> do_cook(meal)
 
 /*
 
@@ -392,95 +354,6 @@ What do you feel like making?
     {MaintFatigued(task)}
 - else:
     {MaintComplete(task)}
-}
--> pass_time(1)
-
-/*
-
-    Cook a Special Meal
-    A chosen recipe from the cooking sub-menu. Costs 2 AP.
-    Fresh ingredient meals get a larger morale boost.
-
-*/
-= do_cook(meal)
-{ PurchasedIngredients ? meal:
-    ~ Morale = MIN(Morale + apply_recreation_bonus(15), 100)
-    ~ PurchasedIngredients -= meal
-- else:
-    ~ Morale = MIN(Morale + apply_recreation_bonus(12), 100)
-}
-{ meal:
-// Standard recipes
-- Curry:     The curry takes all afternoon — dry-toasting spices, building the sauce layer by layer. The ship smells incredible. You eat two bowls.
-- Pho:       You coax a decent broth from dried aromatics and whatever protein's on hand, then drape rice noodles in and watch them soften. It's not Hanoi, but it'll do.
-- JollofRice: You caramelize the tomatoes first, the way your neighbor used to, until they go almost sticky-sweet. The rice drinks up all that smoky red sauce. You scrape the pot.
-- Pupusas:   The corn masa takes some kneading. You stuff them with cheese and a little hot sauce, press them flat, and cook them in a dry pan until the edges crisp. Simple food, honestly satisfying.
-- Borscht:   You dig the last of the beets out of cold storage and make a proper pot of borscht — earthy, deep red, a little sour. You eat it with a spoonful of shelf-stable sour cream substitute. Good enough.
-- Bibimbap:  You fry an egg, lay it over a bowl of rice and whatever pickled vegetables you have left, drizzle on the gochujang sauce you've been hoarding, and mix it all together. The colors alone improve your mood.
-- Tamales:   The masa-spreading is meditative work. You fold each one slowly, steam the whole batch, and let them rest. Unwrapping the first one, the dough pulling back from the husk, feels like a small ceremony.
-- DimSum:    You fold dumplings one by one, pinching each pleat into place. It takes an hour and your hands start to cramp. The first one you steam, you eat standing at the stove.
-- Shakshuka: The whole dish comes together in one pan — tomatoes, peppers, a generous hand with the cumin, then eggs cracked straight in. You eat it with flatbread and watch the stars.
-- Pierogi:   Boiled first, then pan-fried in a little oil until the skins blister and turn golden. You eat them standing up over the stove before they even cool down.
-- Feijoada:  The black beans simmer low and slow with smoked seasonings until they're silky and rich. You serve it over rice with a few drops of hot sauce. It's the kind of meal that makes the ship feel like home.
-- Bannock:   Just flour, water, a pinch of salt, fried in the pan. You don't know why it tastes so good — maybe because it's simple, and simple things feel true out here.
-// Fresh ingredient meals
-- EarthStrawberries:   You hull the strawberries one by one — they're impossibly red, sweet in a way that nothing packaged ever is. The shortcake is rough around the edges, but the berries make it perfect.
-- EarthWagyu:          You pat the steak dry, season it with just salt, and sear it in a screaming-hot pan. It's too good for this kitchen. You eat it slowly.
-- LunaHerbs:           Fresh herbs change everything. The smell when you bruise the rosemary hits you like a memory — green and earthy, nothing like the dried stuff. The fish is simple, the herbs do all the work.
-- LunaCheese:          You melt the cave-aged cheese slowly with a splash of wine and a clove of garlic, kept just below a simmer. The fondue is ridiculous for a cargo ship. You don't care.
-- MarsPeppers:         Greenhouse peppers, deep red and glossy. You roast them until the skins char, then stuff them with spiced rice and bake. The ship smells like somewhere people live on purpose.
-- MarsHoney:           You glaze the ribs in the Olympus honey — dark, almost bitter, earthy in a way that Earth honey isn't. The roasting smells extraordinary. You feel briefly, absurdly, like a person who has their life together.
-- CeresTruffles:       One truffle, shaved paper-thin over a bowl of risotto, transforms a routine meal into something you'd pay for. You eat it slowly and say nothing.
-- CeresSake:           You marinate the fish overnight in sake and soy, then broil it until the glaze caramelizes. The belt-brewed sake has a rougher edge than anything from the inner system. It works.
-- GanymedeIceCream:    You assemble the sundae with the ceremonial focus it deserves. Two scoops of real cream ice cream from Ganymede dairy. Synthetic chocolate sauce. You sit in the captain's chair and eat it while the stars drift past.
-- GanymedeSalt:        You crust the bread dough in Europan salt crystals and bake it in the ship's tiny oven. It comes out uneven and slightly dense. It's still the best bread you've had in months.
-- TitanMeats:          You arrange the cured meats on a tray with crackers and the last of the good mustard. It's a ridiculous extravagance for a hauling run. That's exactly the point.
-- TitanBerries:        You make the cobbler in a single pan — berries tumbled in with a crumble topping, baked until the juice runs and bubbles at the edges. You eat it warm with reconstituted cream.
-}
--> pass_time(2)
-
-/*
-
-    Recreation
-    Flexible recreation handler. Cost and morale boost are parameters.
-
-*/
-= do_recreation(cost, morale_boost)
-~ Morale = MIN(Morale + apply_recreation_bonus(morale_boost), 100)
-{ cost > 1:
-    You settle in for a movie. For a couple of hours, you're not a trucker — you're just an audience.
-    { shuffle:
-    -   You heat up a bag of protein puffs — technically popcorn-flavored — and eat them one at a time.
-    -   You bring a bulb of coffee and a ration bar. The bar's gone before the opening credits.
-    -   You eat nothing, which you'll regret later. But the movie's good enough that you don't notice.
-    }
-- else:
-    You run through a quick workout routine. Your muscles thank you.
-    { shuffle:
-    -   Afterward you eat a protein bar standing over the sink. You've earned it.
-    -   Afterward you drain a full bulb of water and dig out a ration pack. The fatigue makes everything taste better.
-    -   Afterward you sit on the floor for a minute, then eat crackers straight from the bag. No regrets.
-    }
-}
--> pass_time(cost)
-
-= do_video_games
-~ Morale = MIN(Morale + apply_recreation_bonus(10), 100)
-{ shuffle:
--   You boot up a game on the entertainment console. Time melts away as you get absorbed in the action.
--   You spend some time gaming. It's a nice escape from the monotony of deep space hauling.
--   The entertainment system loads your saved game. For a while, you forget you're hurtling through the void.
--   You lose an hour to a dogfighting sim. Ironic, given your actual job.
-}
--> pass_time(1)
-
-= do_listen_music
-~ Morale = MIN(Morale + apply_recreation_bonus(5), 100)
-{ shuffle:
--   You put on some music and let it fill the cockpit. The ship feels less empty.
--   You queue up a playlist and let the music wash over you. Simple pleasures.
--   Music drifts through the ship. You catch yourself humming along.
--   Something melancholy tonight. It fits the mood, somehow.
 }
 -> pass_time(1)
 
@@ -632,20 +505,6 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
     -> passenger_satisfaction_check ->
     -> pick_passenger_task ->
 }
-// Morale decay: faster if ship is dirty
-{ ShipCondition < 50:
-    ~ Morale = MAX(Morale - 3, 0)
-- else:
-    ~ Morale = MAX(Morale - 1, 0)
-}
-// Low morale reduces effective AP
-{ Morale < 20:
-    ~ AP = MIN(AP, 4)
-- else:
-    { Morale < 40:
-        ~ AP = MIN(AP, 5)
-    }
-}
 { ShipClock == 0:
     -> arrive_in_port(ShipDestination)
 }
@@ -706,7 +565,7 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
     - 1: ~ return (not FlipDone and TripDay >= TripDuration / 2)
     - 2: ~ return (EngineCondition < 80) or (Fatigue >= 70)
     - 3: ~ return (PaperworkDone < PaperworkTotal) or (TripDay >= NavCheckDueDay) or (TripDay >= CargoCheckDueDay) or (LIST_COUNT(Backlog) > 0) or (DailyPassengerTask != () and not PassengerTaskCompleted)
-    - 4: ~ return true  // Relax is always available
+    - 4: ~ return Fatigue >= 30 and Fatigue < 70
 }
 ~ return false
 
@@ -786,10 +645,6 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
 - NavGyroCalib:   ~ return "nav gyroscope calibration"
 - CargoSensor:    ~ return "cargo sensor recalibration"
 - CargoSealCheck: ~ return "cargo bay seal check"
-- EntWiring:      ~ return "entertainment system wiring check"
-- EntDisplayClean: ~ return "display panel cleaning"
-- WellSanitize:   ~ return "wellness suite sanitization"
-- WellCalib:      ~ return "autodoc calibration"
 - PaxLifeSupp:    ~ return "passenger life support check"
 - PaxBerthClean:  ~ return "passenger berth cleaning"
 }
@@ -817,10 +672,6 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
 - NavGyroCalib:   ~ return "You recalibrate the navigation gyroscopes. Heading data looks solid."
 - CargoSensor:    ~ return "You recalibrate the cargo bay sensors. Weight readings are accurate again."
 - CargoSealCheck: ~ return "You inspect the cargo bay seals and tighten the loose ones."
-- EntWiring:      ~ return "You trace the entertainment system wiring and fix a dodgy connection."
-- EntDisplayClean: ~ return "You clean the display panels. The picture's crisp again."
-- WellSanitize:   ~ return "You run the wellness suite through a full sanitization cycle."
-- WellCalib:      ~ return "You recalibrate the autodoc's sensors. Readings are precise again."
 - PaxLifeSupp:    ~ return "You run through the passenger life support diagnostics. Air and water systems nominal."
 - PaxBerthClean:  ~ return "You clean the passenger berths and restock the basics. Everything looks presentable."
 }
@@ -848,10 +699,6 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
 - NavGyroCalib:   ~ return "You attempt the gyro calibration but the numbers swim. Close enough."
 - CargoSensor:    ~ return "You poke at the sensor calibration. The readings are... better."
 - CargoSealCheck: ~ return "You check a few seals but skip the hard-to-reach ones."
-- EntWiring:      ~ return "You jiggle a wire until the static clears. Engineering at its finest."
-- EntDisplayClean: ~ return "You smear the displays more than clean them."
-- WellSanitize:   ~ return "You run a quick sanitization cycle. Probably killed most of the germs."
-- WellCalib:      ~ return "You squint at the autodoc readings and call it calibrated."
 - PaxLifeSupp:    ~ return "You half-check the passenger life support. Probably fine."
 - PaxBerthClean:  ~ return "You give the berths a quick once-over. It'll have to do."
 }
@@ -869,7 +716,7 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
 - AirFilter:      ~ return "The air smells stale and metallic. Those filters are long overdue."
 - HullCheck:      ~ return "You hear a creak you don't recognize. Should have checked the hull."
 - DrainLines:     ~ return "The drains are backing up. Should have flushed them when you had the chance."
-- Scrub:          ~ return "The common areas are getting grimy. Morale isn't the only thing suffering."
+- Scrub:          ~ return "The common areas are getting grimy. It's starting to smell in here."
 // Module tasks
 - RepDroneServo:  ~ return "The repair drone's arm is jerking erratically. The servos needed attention."
 - RepDroneOptics: ~ return "The repair drone keeps bumping into things. Its optics are filthy."
@@ -879,10 +726,6 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
 - NavGyroCalib:   ~ return "Course heading keeps drifting. The gyroscopes are way out of spec."
 - CargoSensor:    ~ return "The cargo sensors are giving bogus readings. Hope nothing shifted."
 - CargoSealCheck: ~ return "You hear a whistle near the cargo bay. The seals are loosening."
-- EntWiring:      ~ return "The entertainment system is glitching out. Wiring issue, probably."
-- EntDisplayClean: ~ return "The displays are so grimy you can barely read them."
-- WellSanitize:   ~ return "The wellness suite smells like a gym locker. Sanitization is overdue."
-- WellCalib:      ~ return "The autodoc's readings are drifting. Can't trust it like this."
 - PaxLifeSupp:    ~ return "The passenger section air smells recycled and stale. Life support needed attention."
 - PaxBerthClean:  ~ return "The passenger berths are getting grimy. Someone left a polite but firm note."
 }
@@ -895,48 +738,6 @@ You call it a day and stretch out in your bunk, watching the stars drift past th
 ~ CompletedToday = ()
 ~ MaintCooldown = ()
 ~ add_daily_tasks()
-
-// Returns the display name for a recipe or fresh ingredient meal.
-=== function recipe_name(meal)
-{ meal:
-// Standard recipes — named with personal connection
-- Curry:             ~ return "Grandma's yellow curry"
-- Pho:               ~ return "the pho recipe from back home"
-- JollofRice:        ~ return "Uncle Kofi's jollof rice"
-- Pupusas:           ~ return "the pupusas you learned to make at seventeen"
-- Borscht:           ~ return "borscht (your old neighbor's recipe)"
-- Bibimbap:          ~ return "bibimbap the way you like it"
-- Tamales:           ~ return "holiday tamales"
-- DimSum:            ~ return "homemade dumplings"
-- Shakshuka:         ~ return "shakshuka for one"
-- Pierogi:           ~ return "fried pierogi"
-- Feijoada:          ~ return "Sunday feijoada"
-- Bannock:           ~ return "Grandpa's bannock"
-// Fresh ingredient meals — named to feature the special ingredient
-- EarthStrawberries: ~ return "shortcake with real Earth strawberries"
-- EarthWagyu:        ~ return "pan-seared wagyu steak"
-- LunaHerbs:         ~ return "fish with fresh Luna herbs"
-- LunaCheese:        ~ return "cave-aged cheese fondue"
-- MarsPeppers:       ~ return "stuffed Mars greenhouse peppers"
-- MarsHoney:         ~ return "ribs glazed with Olympus honey"
-- CeresTruffles:     ~ return "risotto with asteroid truffles"
-- CeresSake:         ~ return "sake-glazed salmon"
-- GanymedeIceCream:  ~ return "Ganymede dairy ice cream sundae"
-- GanymedeSalt:      ~ return "salt-crusted bread (Europan sea salt)"
-- TitanMeats:        ~ return "charcuterie with Titan-cured meats"
-- TitanBerries:      ~ return "cobbler with cryo-preserved berries"
-}
-~ return "something"
-
-// Apply Entertainment System morale bonus to a base recreation boost.
-// At 75%+ condition: +50% bonus (base + base / 2, integer math).
-// Otherwise: base unchanged.
-=== function apply_recreation_bonus(base_boost)
-~ temp bonus = 0
-{ get_module_condition(Entertainment) >= 75:
-    ~ bonus = base_boost / 2
-}
-~ return base_boost + bonus
 
 // Complete a maintenance task: remove from backlog/stale, add to cooldown.
 // Replacement tasks are generated at start of next day, not immediately.

--- a/space-truckers.ink
+++ b/space-truckers.ink
@@ -25,8 +25,7 @@ VAR ShipCargo = ()
 VAR FlightMode = Bal
 
 VAR Fatigue = 0           // 0–100 scale. Gravity-modified accumulation.
-VAR Morale = 80           // 0–100 scale. Decays daily, boosted by recreation.
-VAR ShipCondition = 100   // 0–100%. Degrades from skipped maintenance. Affects morale.
+VAR ShipCondition = 100   // 0–100%. Degrades from skipped maintenance.
 VAR EngineCondition = 100 // 0–100%. Degrades from skipped maintenance. Affects fuel cost.
 
 // Maintenance backlog — 3-4 new tasks drawn daily via two-stage selection.
@@ -34,7 +33,7 @@ VAR EngineCondition = 100 // 0–100%. Degrades from skipped maintenance. Affect
 // Skipped tasks age: fresh → stale → auto-resolve with condition penalty.
 LIST EngineMaintTasks = EngTune, FuelLine, Injector, Coolant
 LIST ShipMaintTasks = AirFilter, HullCheck, DrainLines, Scrub
-LIST ModuleMaintTasks = RepDroneServo, RepDroneOptics, ClnDroneBrush, ClnDroneFilter, NavChipFlush, NavGyroCalib, CargoSensor, CargoSealCheck, EntWiring, EntDisplayClean, WellSanitize, WellCalib, PaxLifeSupp, PaxBerthClean
+LIST ModuleMaintTasks = RepDroneServo, RepDroneOptics, ClnDroneBrush, ClnDroneFilter, NavChipFlush, NavGyroCalib, CargoSensor, CargoSealCheck, PaxLifeSupp, PaxBerthClean
 VAR Backlog = ()          // current maintenance tasks (accumulates daily)
 VAR StaleBacklog = ()     // tasks that survived yesterday without completion
 VAR CompletedToday = ()   // tasks completed this day, becomes tomorrow's cooldown
@@ -58,13 +57,8 @@ VAR EventChance = 0        // Escalating probability for random events (0–100)
 VAR EventCooldownDay = -1  // TripDay of last event; prevents pile-ups same day
 VAR CargoDamagePct = 0     // Accumulated cargo damage % (reduces delivery pay)
 
-// Fresh ingredients — purchasable at port, unlock premium cooking options in transit.
-// Each item corresponds to a port-specific ingredient and a named meal in do_cook().
-LIST FreshIngredients = EarthStrawberries, EarthWagyu, LunaHerbs, LunaCheese, MarsPeppers, MarsHoney, CeresTruffles, CeresSake, GanymedeIceCream, GanymedeSalt, TitanMeats, TitanBerries
-VAR PurchasedIngredients = ()  // subset of FreshIngredients currently in the galley
-
 // Module system — ship modules that automate routine tasks.
-LIST ShipModules = RepairDrones, CleaningDrones, AutoNav, CargoMgmt, Entertainment, WellnessSuite, PassengerModule
+LIST ShipModules = RepairDrones, CleaningDrones, AutoNav, CargoMgmt, PassengerModule
 LIST ModuleStats = ModName, ModPrice, ModDesc
 VAR InstalledModules = ()      // currently installed modules
 VAR RefurbishedModules = ()    // subset of InstalledModules bought refurbished (80% max cap)
@@ -75,8 +69,6 @@ VAR RepairDronesCondition = 0
 VAR CleaningDronesCondition = 0
 VAR AutoNavCondition = 0
 VAR CargoMgmtCondition = 0
-VAR EntertainmentCondition = 0
-VAR WellnessSuiteCondition = 0
 VAR PassengerModuleCondition = 0
 VAR PassengerModuleTier = 0       // 0=not installed, 1=Basic Berths, 2=Standard Cabin, 3=Luxury Suite
 

--- a/tests/integration/events.test.js
+++ b/tests/integration/events.test.js
@@ -67,7 +67,6 @@ function setupTransit(overrides = {}) {
     AP: 6,
     ActionPointsMax: 6,
     Fatigue: 0,
-    Morale: 80,
     ShipCondition: 100,
     EngineCondition: 100,
     ShipFuel: 200,
@@ -109,7 +108,6 @@ function setupEvent(eventKnot, overrides = {}) {
     AP: 6,
     ActionPointsMax: 6,
     Fatigue: 0,
-    Morale: 80,
     ShipCondition: 100,
     EngineCondition: 100,
     ShipFuel: 200,
@@ -139,7 +137,7 @@ describe("Event triggering", () => {
     const story = setupTransit({ EventChance: 0 });
     // If an event had fired, the story would have diverted before presenting
     // normal task choices. Verify we got normal choices instead.
-    expect(hasChoice(story, "Take a break")).toBe(true);
+    expect(hasChoice(story, "Call it a day")).toBe(true);
   });
 
   it("events do not repeat within a trip", () => {
@@ -166,7 +164,6 @@ describe("Event triggering", () => {
     story.variablesState["AP"] = 6;
     story.variablesState["ActionPointsMax"] = 6;
     story.variablesState["Fatigue"] = 0;
-    story.variablesState["Morale"] = 80;
     story.variablesState["ShipCondition"] = 100;
     story.variablesState["EngineCondition"] = 100;
     story.variablesState["ShipFuel"] = 200;
@@ -213,7 +210,6 @@ describe("Event triggering", () => {
     story.variablesState["AP"] = 6;
     story.variablesState["ActionPointsMax"] = 6;
     story.variablesState["Fatigue"] = 0;
-    story.variablesState["Morale"] = 80;
     story.variablesState["ShipCondition"] = 100;
     story.variablesState["EngineCondition"] = 100;
     story.variablesState["ShipFuel"] = 200;
@@ -248,7 +244,7 @@ describe("Event triggering", () => {
       EventCooldownDay: 3, // same as default TripDay
     });
     // Cooldown active — should get normal task choices, not an event
-    expect(hasChoice(story, "Take a break")).toBe(true);
+    expect(hasChoice(story, "Call it a day")).toBe(true);
     // EventChance should still have incremented (cooldown blocks event, not increment)
     // Actually per our logic: when in cooldown, we skip the check entirely
     // so EventChance should NOT increment either
@@ -478,7 +474,6 @@ describe("Event: Cargo Shift", () => {
     story.variablesState["AP"] = 6;
     story.variablesState["ActionPointsMax"] = 6;
     story.variablesState["Fatigue"] = 0;
-    story.variablesState["Morale"] = 80;
     story.variablesState["ShipCondition"] = 100;
     story.variablesState["EngineCondition"] = 100;
     story.variablesState["ShipFuel"] = 200;
@@ -521,28 +516,24 @@ describe("Event: Distress Signal", () => {
     expect(story.variablesState["PlayerBankBalance"]).toBe(1500);
   });
 
-  it("share supplies costs 2 AP, awards 150€, and boosts morale", () => {
+  it("share supplies costs 2 AP and awards 150€", () => {
     const story = setupEvent("event_distress_signal", {
       AP: 6,
       PlayerBankBalance: 1000,
-      Morale: 60,
     });
     pickChoice(story, "Share some supplies");
     expect(story.variablesState["AP"]).toBe(4); // 6 - 2
     expect(story.variablesState["PlayerBankBalance"]).toBe(1150);
-    expect(story.variablesState["Morale"]).toBe(70); // 60 + 10
   });
 
   it("send relay costs 0 AP and has no reward", () => {
     const story = setupEvent("event_distress_signal", {
       AP: 6,
       PlayerBankBalance: 1000,
-      Morale: 60,
     });
     pickChoice(story, "Send a distress relay");
     expect(story.variablesState["AP"]).toBe(6); // unchanged
     expect(story.variablesState["PlayerBankBalance"]).toBe(1000); // unchanged
-    expect(story.variablesState["Morale"]).toBe(60); // unchanged
   });
 });
 

--- a/tests/integration/modules.test.js
+++ b/tests/integration/modules.test.js
@@ -58,7 +58,6 @@ function setupTransit(overrides = {}) {
     AP: 6,
     ActionPointsMax: 6,
     Fatigue: 0,
-    Morale: 80,
     ShipCondition: 100,
     EngineCondition: 100,
     ShipFuel: 200,
@@ -104,8 +103,6 @@ describe("task classification", () => {
       ["ModuleMaintTasks.ClnDroneBrush", "ShipModules.CleaningDrones"],
       ["ModuleMaintTasks.NavChipFlush", "ShipModules.AutoNav"],
       ["ModuleMaintTasks.CargoSensor", "ShipModules.CargoMgmt"],
-      ["ModuleMaintTasks.EntWiring", "ShipModules.Entertainment"],
-      ["ModuleMaintTasks.WellSanitize", "ShipModules.WellnessSuite"],
     ];
     for (const [task, mod] of cases) {
       const result = story.EvaluateFunction("maint_task_module", [L(story, task)]);
@@ -288,8 +285,6 @@ describe("backlog accumulation", () => {
       expect(backlog).not.toContain("Drone");
       expect(backlog).not.toContain("Nav");
       expect(backlog).not.toContain("Cargo");
-      expect(backlog).not.toContain("Ent");
-      expect(backlog).not.toContain("Well");
     }
   });
 });
@@ -345,11 +340,12 @@ describe("module maintenance effects", () => {
     s.variablesState["StaleBacklog"] = L(s, "ModuleMaintTasks.RepDroneServo");
     s.variablesState["ShipClock"] = 5;
     s.variablesState["TripDay"] = 2;
+    s.variablesState["NavCheckDueDay"] = 2; // make nav check available to burn AP
 
     s.ChoosePathString("transit.ship_options");
     drainText(s);
-    pickChoice(s, "Take a break");
-    pickChoice(s, "Quick workout"); // costs 1 AP → AP=0 → next_day fires
+    pickChoice(s, "Navigation check"); // costs 1 AP → AP=0 → next_day fires; backlog untouched
+    drainText(s);
 
     // RepairDrones should have lost 5 condition
     expect(s.EvaluateFunction("get_module_condition", [L(s, "ShipModules.RepairDrones")])).toBe(55);
@@ -365,11 +361,12 @@ describe("module maintenance effects", () => {
     s.variablesState["StaleBacklog"] = L(s, "ModuleMaintTasks.RepDroneServo");
     s.variablesState["ShipClock"] = 5;
     s.variablesState["TripDay"] = 2;
+    s.variablesState["NavCheckDueDay"] = 2; // make nav check available to burn AP
 
     s.ChoosePathString("transit.ship_options");
     drainText(s);
-    pickChoice(s, "Take a break");
-    pickChoice(s, "Quick workout"); // costs 1 AP → AP=0 → next_day fires
+    pickChoice(s, "Navigation check"); // costs 1 AP → AP=0 → next_day fires; backlog untouched
+    drainText(s);
 
     expect(s.EvaluateFunction("get_module_condition", [L(s, "ShipModules.RepairDrones")])).toBe(1);
   });
@@ -398,7 +395,6 @@ describe("narrative text functions", () => {
     const tasks = [
       "RepDroneServo", "RepDroneOptics", "ClnDroneBrush", "ClnDroneFilter",
       "NavChipFlush", "NavGyroCalib", "CargoSensor", "CargoSealCheck",
-      "EntWiring", "EntDisplayClean", "WellSanitize", "WellCalib",
     ];
     for (const task of tasks) {
       const name = story.EvaluateFunction("MaintName", [L(story, `ModuleMaintTasks.${task}`)]);
@@ -676,75 +672,3 @@ describe("Cargo Management System", () => {
   });
 });
 
-describe("Wellness Suite", () => {
-  it("reduces fatigue and boosts morale at full condition (75%+)", () => {
-    const s = setupTransit({ Fatigue: 40, Morale: 70 });
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.WellnessSuite"), 100]);
-    s.EvaluateFunction("module_auto_tasks");
-    expect(s.variablesState["Fatigue"]).toBe(35);
-    expect(s.variablesState["Morale"]).toBe(72);
-  });
-
-  it("reduces fatigue and boosts morale at reduced condition (50-74%)", () => {
-    const s = setupTransit({ Fatigue: 40, Morale: 70 });
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.WellnessSuite"), 60]);
-    s.EvaluateFunction("module_auto_tasks");
-    expect(s.variablesState["Fatigue"]).toBe(37);
-    expect(s.variablesState["Morale"]).toBe(71);
-  });
-
-  it("does nothing when offline (below 50%)", () => {
-    const s = setupTransit({ Fatigue: 40, Morale: 70 });
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.WellnessSuite"), 40]);
-    s.EvaluateFunction("module_auto_tasks");
-    expect(s.variablesState["Fatigue"]).toBe(40);
-    expect(s.variablesState["Morale"]).toBe(70);
-  });
-
-  it("floors fatigue at 0, not negative", () => {
-    const s = setupTransit({ Fatigue: 3, Morale: 50 });
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.WellnessSuite"), 100]);
-    s.EvaluateFunction("module_auto_tasks");
-    expect(s.variablesState["Fatigue"]).toBe(0);
-  });
-
-  it("caps morale at 100, not above", () => {
-    const s = setupTransit({ Fatigue: 20, Morale: 99 });
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.WellnessSuite"), 100]);
-    s.EvaluateFunction("module_auto_tasks");
-    expect(s.variablesState["Morale"]).toBe(100);
-  });
-});
-
-describe("Entertainment System", () => {
-  it("video games choice appears inside relax sub-menu when Entertainment is active", () => {
-    const s = setupTransit();
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.Entertainment"), 100]);
-
-    s.ChoosePathString("transit.ship_options");
-    drainText(s);
-    pickChoice(s, "Take a break");
-    expect(hasChoice(s, "Play video games")).toBe(true);
-  });
-
-  it("listen to music choice appears inside relax sub-menu when Entertainment is active", () => {
-    const s = setupTransit();
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.Entertainment"), 100]);
-
-    s.ChoosePathString("transit.ship_options");
-    drainText(s);
-    pickChoice(s, "Take a break");
-    expect(hasChoice(s, "Listen to music")).toBe(true);
-  });
-
-  it("entertainment choices do not appear when module is offline (below 50%)", () => {
-    const s = setupTransit();
-    s.EvaluateFunction("install_module", [L(s, "ShipModules.Entertainment"), 40]);
-
-    s.ChoosePathString("transit.ship_options");
-    drainText(s);
-    pickChoice(s, "Take a break");
-    expect(hasChoice(s, "Play video games")).toBe(false);
-    expect(hasChoice(s, "Listen to music")).toBe(false);
-  });
-});

--- a/tests/integration/passengers.test.js
+++ b/tests/integration/passengers.test.js
@@ -56,7 +56,6 @@ function setupTransit(overrides = {}) {
     AP: 1, // 1 AP so next action triggers next_day
     ActionPointsMax: 6,
     Fatigue: 0,
-    Morale: 80,
     ShipCondition: 100,
     EngineCondition: 100,
     ShipFuel: 200,
@@ -169,10 +168,12 @@ describe("Satisfaction — skip penalty and passive bonus from next_day", () => 
    * Sets up AP=1 so the workout consumes all AP, triggering next_day.
    */
   function triggerNextDay(s) {
+    s.variablesState["Backlog"] = L(s, "ShipMaintTasks.AirFilter");
     s.ChoosePathString("transit.ship_options");
     drainText(s);
-    pickChoice(s, "Take a break");
-    pickChoice(s, "Quick workout"); // 1 AP → AP=0 → next_day fires
+    pickChoice(s, "Ship maintenance");
+    s.ChooseChoiceIndex(0); // pick first maintenance task — 1 AP → AP=0 → next_day fires
+    drainText(s);
   }
 
   it("skipping the daily task applies -3 satisfaction penalty", () => {

--- a/tests/integration/transit.test.js
+++ b/tests/integration/transit.test.js
@@ -85,7 +85,6 @@ function setupTransit(overrides = {}) {
     AP: 6,
     ActionPointsMax: 6,
     Fatigue: 0,
-    Morale: 80,
     ShipCondition: 100,
     EngineCondition: 100,
     ShipFuel: 200,
@@ -217,12 +216,7 @@ describe("Task priority system", () => {
     });
   });
 
-  describe("P4: Recreation", () => {
-    it("shows relax option on a quiet day", () => {
-      const story = setupTransit();
-      expect(hasChoice(story, "Take a break")).toBe(true);
-    });
-
+  describe("P4: Rest", () => {
     it("shows sleep rest when fatigue is moderate (30-69)", () => {
       const story = setupTransit({ Fatigue: 50 });
       expect(hasChoice(story, "Get some rest")).toBe(true);
@@ -234,24 +228,6 @@ describe("Task priority system", () => {
       const story = setupTransit({ Fatigue: 20 });
       // "Get some rest" should not appear at all (neither P2 nor P4)
       expect(hasChoice(story, "Get some rest")).toBe(false);
-    });
-  });
-
-  describe("P4 floor guarantee", () => {
-    it("shows at least 1 P4 task even when many P1-P3 are active", () => {
-      const story = setupTransit({
-        FlipDone: false,
-        TripDay: 6, // midpoint AND nav check day
-        TripDuration: 10,
-        NavCheckDueDay: 6,
-        EngineCondition: 70,
-        Fatigue: 75,
-        PaperworkDone: 0,
-        PaperworkTotal: 3,
-        ShipCondition: 70,
-      });
-      // With 6 P1-P3 tasks, P4 should still have at least 1 slot
-      expect(hasChoice(story, "Take a break")).toBe(true);
     });
   });
 
@@ -366,24 +342,6 @@ describe("Task priority system", () => {
   });
 
   describe("Sub-menus", () => {
-    it("relax sub-menu shows cooking, workout, and movie", () => {
-      const story = setupTransit();
-      pickChoice(story, "Take a break");
-      expect(hasChoice(story, "Cook a special meal")).toBe(true);
-      expect(hasChoice(story, "workout")).toBe(true);
-      expect(hasChoice(story, "movie")).toBe(true);
-      expect(hasChoice(story, "Never mind")).toBe(true);
-    });
-
-    it("relax Never mind returns to top-level without spending AP", () => {
-      const story = setupTransit({ AP: 6 });
-      pickChoice(story, "Take a break");
-      pickChoice(story, "Never mind");
-      expect(story.variablesState["AP"]).toBe(6);
-      // Should be back at ship_options with choices available
-      expect(story.currentChoices.length).toBeGreaterThan(0);
-    });
-
     it("sleep sub-menu shows nap when fatigue >= 30", () => {
       const story = setupTransit({ Fatigue: 50 });
       pickChoice(story, "Get some rest");

--- a/tests/unit/modules.test.js
+++ b/tests/unit/modules.test.js
@@ -46,15 +46,6 @@ describe("get_module_condition / set_module_condition", () => {
     expect(story.EvaluateFunction("get_module_condition", [L(story, "ShipModules.CargoMgmt")])).toBe(65);
   });
 
-  it("round-trips Entertainment condition", () => {
-    story.EvaluateFunction("set_module_condition", [L(story, "ShipModules.Entertainment"), 90]);
-    expect(story.EvaluateFunction("get_module_condition", [L(story, "ShipModules.Entertainment")])).toBe(90);
-  });
-
-  it("round-trips WellnessSuite condition", () => {
-    story.EvaluateFunction("set_module_condition", [L(story, "ShipModules.WellnessSuite"), 55]);
-    expect(story.EvaluateFunction("get_module_condition", [L(story, "ShipModules.WellnessSuite")])).toBe(55);
-  });
 });
 
 describe("is_module_active", () => {
@@ -169,20 +160,8 @@ describe("ModuleData", () => {
     expect(story.EvaluateFunction("ModuleData", [L(story, "ShipModules.CargoMgmt"), L(story, "ModuleStats.ModPrice")])).toBe(700);
   });
 
-  it("returns correct price for Entertainment", () => {
-    expect(story.EvaluateFunction("ModuleData", [L(story, "ShipModules.Entertainment"), L(story, "ModuleStats.ModPrice")])).toBe(400);
-  });
-
-  it("returns correct price for WellnessSuite", () => {
-    expect(story.EvaluateFunction("ModuleData", [L(story, "ShipModules.WellnessSuite"), L(story, "ModuleStats.ModPrice")])).toBe(500);
-  });
-
   it("returns correct name for AutoNav", () => {
     expect(story.EvaluateFunction("ModuleData", [L(story, "ShipModules.AutoNav"), L(story, "ModuleStats.ModName")])).toBe("Auto-Nav Computer");
-  });
-
-  it("returns correct name for WellnessSuite", () => {
-    expect(story.EvaluateFunction("ModuleData", [L(story, "ShipModules.WellnessSuite"), L(story, "ModuleStats.ModName")])).toBe("Wellness Suite");
   });
 });
 
@@ -200,52 +179,3 @@ describe("install_module", () => {
   });
 });
 
-describe("has_medical_module", () => {
-  it("returns false when WellnessSuite not installed", () => {
-    expect(story.EvaluateFunction("has_medical_module")).toBe(false);
-  });
-
-  it("returns false when WellnessSuite installed but below 50%", () => {
-    story.EvaluateFunction("install_module", [L(story, "ShipModules.WellnessSuite"), 49]);
-    expect(story.EvaluateFunction("has_medical_module")).toBe(false);
-  });
-
-  it("returns true when WellnessSuite installed and active (50%+)", () => {
-    story.EvaluateFunction("install_module", [L(story, "ShipModules.WellnessSuite"), 50]);
-    expect(story.EvaluateFunction("has_medical_module")).toBe(true);
-  });
-
-  it("returns true when WellnessSuite installed at full condition", () => {
-    story.EvaluateFunction("install_module", [L(story, "ShipModules.WellnessSuite"), 100]);
-    expect(story.EvaluateFunction("has_medical_module")).toBe(true);
-  });
-});
-
-describe("apply_recreation_bonus", () => {
-  it("returns base boost when Entertainment not installed", () => {
-    expect(story.EvaluateFunction("apply_recreation_bonus", [10])).toBe(10);
-  });
-
-  it("returns base boost when Entertainment installed but below 75%", () => {
-    story.EvaluateFunction("install_module", [L(story, "ShipModules.Entertainment"), 74]);
-    expect(story.EvaluateFunction("apply_recreation_bonus", [10])).toBe(10);
-  });
-
-  it("returns +50% bonus when Entertainment is at 75%+", () => {
-    story.EvaluateFunction("install_module", [L(story, "ShipModules.Entertainment"), 75]);
-    // 10 + 10/2 = 15
-    expect(story.EvaluateFunction("apply_recreation_bonus", [10])).toBe(15);
-  });
-
-  it("applies integer truncation correctly for odd base values", () => {
-    story.EvaluateFunction("install_module", [L(story, "ShipModules.Entertainment"), 100]);
-    // 3 + 3/2 = 3 + 1 = 4 (integer division)
-    expect(story.EvaluateFunction("apply_recreation_bonus", [3])).toBe(4);
-    // 5 + 5/2 = 5 + 2 = 7
-    expect(story.EvaluateFunction("apply_recreation_bonus", [5])).toBe(7);
-    // 8 + 8/2 = 8 + 4 = 12
-    expect(story.EvaluateFunction("apply_recreation_bonus", [8])).toBe(12);
-    // 15 + 15/2 = 15 + 7 = 22
-    expect(story.EvaluateFunction("apply_recreation_bonus", [15])).toBe(22);
-  });
-});


### PR DESCRIPTION
Closes #49. Part of the morale rework epic (#38).

## Summary

- **Removes `VAR Morale`** and all connected logic: daily decay, AP penalties at <20/<40, and ~15 event mutations
- **Removes recreation menu**: Relax task, Cook (24 recipes + fresh ingredients), Video Games, Listen Music, relax sub-menu, `apply_recreation_bonus()`, `recipe_name()`
- **Removes port shopping**: `go_shopping` knot, `FreshIngredientData`, `FreshIngredients` LIST, `PurchasedIngredients` VAR
- **Removes Entertainment System module**: `ModuleData` entry, `EntertainmentCondition` VAR, maintenance tasks (`EntWiring`, `EntDisplayClean`), all `is_module_active(Entertainment)` checks
- **Removes Wellness Suite module**: `ModuleData` entry, `WellnessSuiteCondition` VAR, maintenance tasks (`WellSanitize`, `WellCalib`), `process_wellness` stitch, `has_medical_module()` function
- **Medical emergency** reworked: uses base odds unconditionally (50% improve / 40% worsen / 10% death) — no module dependency
- **`has_tier_tasks(4)`** updated: returns `Fatigue >= 30 and Fatigue < 70` (SleepRest is now the only P4 task)
- **Port arrival text** replaced with non-food station atmosphere lines
- **Scrub overdue text** rewritten to remove morale reference
- Docs updated: player-guide, developer-guide, project-patterns

## Test plan

- [x] `npm run lint` — passes
- [x] `npm test` — 499 tests pass (12 test files)
- [x] Only one commit ahead of `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)